### PR TITLE
Add Qt6 support

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,25 @@
+name: Clang Format Check
+
+on: [push, pull_request]
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: Install clang-format
+        run: pip install clang-format
+
+      - name: Check code format
+        run: |
+          FILES=$(git ls-files 'cpp/*.cpp' 'cpp/*.h')
+          clang-format -i $FILES
+          git diff --exit-code

--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -11,13 +11,18 @@ on:
 jobs:
   build_and_test:
     name: Build  and Test
+    strategy:
+      matrix:
+        qt_version:
+          - "5.15.2"
+          - "6.8.1"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: "5.15.2"
+          version: ${{ matrix.qt_version }}
           target: "desktop"
       - name: Build and test
         run: cd cpp && cmake . && cmake --build . --verbose && ctest . --verbose

--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -1,0 +1,23 @@
+name: Build and Test
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+    paths:
+      - "cpp/**"
+
+jobs:
+  build_and_test:
+    name: Build  and Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: "5.15.2"
+          target: "desktop"
+      - name: Build and test
+        run: cd cpp && cmake . && cmake --build . --verbose && ctest . --verbose

--- a/cpp/.clang-format
+++ b/cpp/.clang-format
@@ -1,0 +1,3 @@
+---
+BasedOnStyle: Google
+IncludeBlocks: Preserve

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -44,7 +44,7 @@ target_include_directories(${target}
     PRIVATE
         ${QWT_INCLUDE_DIRS}
     PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/>
         $<INSTALL_INTERFACE:include>
 )
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -5,7 +5,7 @@ set(META_PROJECT_NAME        "diff-match-patch")
 set(META_PROJECT_DESCRIPTION "diff-match-patch")
 set(META_VERSION_MAJOR       "0")
 set(META_VERSION_MINOR       "0")
-set(META_VERSION_PATCH       "3")
+set(META_VERSION_PATCH       "4")
 set(META_VERSION             "${META_VERSION_MAJOR}.${META_VERSION_MINOR}.${META_VERSION_PATCH}")
 
 # Define the project itself
@@ -15,7 +15,8 @@ project(${META_PROJECT_NAME}
     LANGUAGES C CXX
 )
 
-find_package(Qt5 REQUIRED COMPONENTS Core)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core)
 
 # Target name
 set(target diff-match-patch)
@@ -50,7 +51,7 @@ target_include_directories(${target}
 # Libraries
 target_link_libraries(${target}
     PUBLIC
-        Qt5::Core
+        Qt${QT_VERSION_MAJOR}::Core
 )
 
 add_executable(

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -24,8 +24,6 @@ set(target diff-match-patch)
 add_library(${target}
     diff_match_patch.h
     diff_match_patch.cpp
-    diff_match_patch_test.h
-    diff_match_patch_test.cpp
 )
 
 # Create namespaced alias
@@ -54,3 +52,14 @@ target_link_libraries(${target}
     PUBLIC
         Qt5::Core
 )
+
+add_executable(
+    diff_match_patch_test
+    diff_match_patch_test.h
+    diff_match_patch_test.cpp
+)
+
+target_link_libraries(diff_match_patch_test PRIVATE diff-match-patch)
+
+enable_testing()
+add_test(NAME diff_match_patch_test COMMAND diff_match_patch_test)

--- a/cpp/diff_match_patch.cpp
+++ b/cpp/diff_match_patch.cpp
@@ -802,6 +802,7 @@ void diff_match_patch::diff_cleanupSemantic(QList<Diff> &diffs) {
           // Overlap found.  Insert an equality and trim the surrounding edits.
           pointer.previous();
           pointer.insert(Diff(Equal, insertion.left(overlap_length1)));
+          thisDiff = &pointer.next();
           prevDiff->text = deletion.left(deletion.length() - overlap_length1);
           thisDiff->text = safeMid(insertion, overlap_length1);
           // pointer.insert inserts the element before the cursor, so there is
@@ -814,6 +815,7 @@ void diff_match_patch::diff_cleanupSemantic(QList<Diff> &diffs) {
           // Insert an equality and swap and trim the surrounding edits.
           pointer.previous();
           pointer.insert(Diff(Equal, deletion.left(overlap_length2)));
+          thisDiff = &pointer.next();
           prevDiff->operation = Insert;
           prevDiff->text = insertion.left(insertion.length() - overlap_length2);
           thisDiff->operation = Delete;

--- a/cpp/diff_match_patch.cpp
+++ b/cpp/diff_match_patch.cpp
@@ -315,8 +315,8 @@ QList<Diff> diff_match_patch::diff_lineMode(QString text1, QString text2,
   QString text_insert = "";
 
   QMutableListIterator<Diff> pointer(diffs);
-  Diff *thisDiff = pointer.hasNext() ? &pointer.next() : NULL;
-  while (thisDiff != NULL) {
+  Diff *thisDiff = pointer.hasNext() ? &pointer.next() : nullptr;
+  while (thisDiff != nullptr) {
     switch (thisDiff->operation) {
       case Insert:
         count_insert++;
@@ -346,7 +346,7 @@ QList<Diff> diff_match_patch::diff_lineMode(QString text1, QString text2,
         text_insert = "";
         break;
     }
-    thisDiff = pointer.hasNext() ? &pointer.next() : NULL;
+    thisDiff = pointer.hasNext() ? &pointer.next() : nullptr;
   }
   diffs.removeLast();  // Remove the dummy entry at the end.
 
@@ -704,8 +704,8 @@ void diff_match_patch::diff_cleanupSemantic(QList<Diff> &diffs) {
   // Number of characters that changed after the equality.
   int length_insertions2 = 0;
   int length_deletions2 = 0;
-  Diff *thisDiff = pointer.hasNext() ? &pointer.next() : NULL;
-  while (thisDiff != NULL) {
+  Diff *thisDiff = pointer.hasNext() ? &pointer.next() : nullptr;
+  while (thisDiff != nullptr) {
     if (thisDiff->operation == Equal) {
       // Equality found.
       equalities.push(*thisDiff);
@@ -766,7 +766,7 @@ void diff_match_patch::diff_cleanupSemantic(QList<Diff> &diffs) {
         changes = true;
       }
     }
-    thisDiff = pointer.hasNext() ? &pointer.next() : NULL;
+    thisDiff = pointer.hasNext() ? &pointer.next() : nullptr;
   }
 
   // Normalize the diff.
@@ -782,15 +782,15 @@ void diff_match_patch::diff_cleanupSemantic(QList<Diff> &diffs) {
   //   -> <ins>def</ins>xxx<del>abc</del>
   // Only extract an overlap if it is as big as the edit ahead or behind it.
   pointer.toFront();
-  Diff *prevDiff = NULL;
-  thisDiff = NULL;
+  Diff *prevDiff = nullptr;
+  thisDiff = nullptr;
   if (pointer.hasNext()) {
     prevDiff = &pointer.next();
     if (pointer.hasNext()) {
       thisDiff = &pointer.next();
     }
   }
-  while (thisDiff != NULL) {
+  while (thisDiff != nullptr) {
     if (prevDiff->operation == Delete && thisDiff->operation == Insert) {
       QString deletion = prevDiff->text;
       QString insertion = thisDiff->text;
@@ -824,10 +824,10 @@ void diff_match_patch::diff_cleanupSemantic(QList<Diff> &diffs) {
           // no need to step past the new element.
         }
       }
-      thisDiff = pointer.hasNext() ? &pointer.next() : NULL;
+      thisDiff = pointer.hasNext() ? &pointer.next() : nullptr;
     }
     prevDiff = thisDiff;
-    thisDiff = pointer.hasNext() ? &pointer.next() : NULL;
+    thisDiff = pointer.hasNext() ? &pointer.next() : nullptr;
   }
 }
 
@@ -839,12 +839,12 @@ void diff_match_patch::diff_cleanupSemanticLossless(QList<Diff> &diffs) {
   QString bestEquality1, bestEdit, bestEquality2;
   // Create a new iterator at the start.
   QMutableListIterator<Diff> pointer(diffs);
-  Diff *prevDiff = pointer.hasNext() ? &pointer.next() : NULL;
-  Diff *thisDiff = pointer.hasNext() ? &pointer.next() : NULL;
-  Diff *nextDiff = pointer.hasNext() ? &pointer.next() : NULL;
+  Diff *prevDiff = pointer.hasNext() ? &pointer.next() : nullptr;
+  Diff *thisDiff = pointer.hasNext() ? &pointer.next() : nullptr;
+  Diff *nextDiff = pointer.hasNext() ? &pointer.next() : nullptr;
 
   // Intentionally ignore the first and last element (don't need checking).
-  while (nextDiff != NULL) {
+  while (nextDiff != nullptr) {
     if (prevDiff->operation == Equal && nextDiff->operation == Equal) {
       // This is a single edit surrounded by equalities.
       equality1 = prevDiff->text;
@@ -906,7 +906,7 @@ void diff_match_patch::diff_cleanupSemanticLossless(QList<Diff> &diffs) {
     }
     prevDiff = thisDiff;
     thisDiff = nextDiff;
-    nextDiff = pointer.hasNext() ? &pointer.next() : NULL;
+    nextDiff = pointer.hasNext() ? &pointer.next() : nullptr;
   }
 }
 
@@ -975,10 +975,10 @@ void diff_match_patch::diff_cleanupEfficiency(QList<Diff> &diffs) {
   // Is there a deletion operation after the last equality.
   bool post_del = false;
 
-  Diff *thisDiff = pointer.hasNext() ? &pointer.next() : NULL;
+  Diff *thisDiff = pointer.hasNext() ? &pointer.next() : nullptr;
   Diff *safeDiff = thisDiff;
 
-  while (thisDiff != NULL) {
+  while (thisDiff != nullptr) {
     if (thisDiff->operation == Equal) {
       // Equality found.
       if (thisDiff->text.length() < Diff_EditCost && (post_ins || post_del)) {
@@ -1057,7 +1057,7 @@ void diff_match_patch::diff_cleanupEfficiency(QList<Diff> &diffs) {
         changes = true;
       }
     }
-    thisDiff = pointer.hasNext() ? &pointer.next() : NULL;
+    thisDiff = pointer.hasNext() ? &pointer.next() : nullptr;
   }
 
   if (changes) {
@@ -1072,20 +1072,20 @@ void diff_match_patch::diff_cleanupMerge(QList<Diff> &diffs) {
   int count_insert = 0;
   QString text_delete = "";
   QString text_insert = "";
-  Diff *thisDiff = pointer.hasNext() ? &pointer.next() : NULL;
-  Diff *prevEqual = NULL;
+  Diff *thisDiff = pointer.hasNext() ? &pointer.next() : nullptr;
+  Diff *prevEqual = nullptr;
   int commonlength;
-  while (thisDiff != NULL) {
+  while (thisDiff != nullptr) {
     switch (thisDiff->operation) {
       case Insert:
         count_insert++;
         text_insert += thisDiff->text;
-        prevEqual = NULL;
+        prevEqual = nullptr;
         break;
       case Delete:
         count_delete++;
         text_delete += thisDiff->text;
-        prevEqual = NULL;
+        prevEqual = nullptr;
         break;
       case Equal:
         if (count_delete + count_insert > 1) {
@@ -1139,9 +1139,9 @@ void diff_match_patch::diff_cleanupMerge(QList<Diff> &diffs) {
             pointer.insert(Diff(Insert, text_insert));
           }
           // Step forward to the equality.
-          thisDiff = pointer.hasNext() ? &pointer.next() : NULL;
+          thisDiff = pointer.hasNext() ? &pointer.next() : nullptr;
 
-        } else if (prevEqual != NULL) {
+        } else if (prevEqual != nullptr) {
           // Merge this equality with the previous one.
           prevEqual->text += thisDiff->text;
           pointer.remove();
@@ -1155,7 +1155,7 @@ void diff_match_patch::diff_cleanupMerge(QList<Diff> &diffs) {
         prevEqual = thisDiff;
         break;
     }
-    thisDiff = pointer.hasNext() ? &pointer.next() : NULL;
+    thisDiff = pointer.hasNext() ? &pointer.next() : nullptr;
   }
   if (diffs.back().text.isEmpty()) {
     diffs.removeLast();  // Remove the dummy entry at the end.
@@ -1170,12 +1170,12 @@ void diff_match_patch::diff_cleanupMerge(QList<Diff> &diffs) {
   // Create a new iterator at the start.
   // (As opposed to walking the current one back.)
   pointer.toFront();
-  Diff *prevDiff = pointer.hasNext() ? &pointer.next() : NULL;
-  thisDiff = pointer.hasNext() ? &pointer.next() : NULL;
-  Diff *nextDiff = pointer.hasNext() ? &pointer.next() : NULL;
+  Diff *prevDiff = pointer.hasNext() ? &pointer.next() : nullptr;
+  thisDiff = pointer.hasNext() ? &pointer.next() : nullptr;
+  Diff *nextDiff = pointer.hasNext() ? &pointer.next() : nullptr;
 
   // Intentionally ignore the first and last element (don't need checking).
-  while (nextDiff != NULL) {
+  while (nextDiff != nullptr) {
     if (prevDiff->operation == Equal && nextDiff->operation == Equal) {
       // This is a single edit surrounded by equalities.
       if (thisDiff->text.endsWith(prevDiff->text)) {
@@ -1190,7 +1190,7 @@ void diff_match_patch::diff_cleanupMerge(QList<Diff> &diffs) {
         pointer.remove();            // Delete prevDiff.
         pointer.next();              // Walk past thisDiff.
         thisDiff = &pointer.next();  // Walk past nextDiff.
-        nextDiff = pointer.hasNext() ? &pointer.next() : NULL;
+        nextDiff = pointer.hasNext() ? &pointer.next() : nullptr;
         changes = true;
       } else if (thisDiff->text.startsWith(nextDiff->text)) {
         // Shift the edit over the next equality.
@@ -1198,13 +1198,13 @@ void diff_match_patch::diff_cleanupMerge(QList<Diff> &diffs) {
         thisDiff->text =
             safeMid(thisDiff->text, nextDiff->text.length()) + nextDiff->text;
         pointer.remove();  // Delete nextDiff.
-        nextDiff = pointer.hasNext() ? &pointer.next() : NULL;
+        nextDiff = pointer.hasNext() ? &pointer.next() : nullptr;
         changes = true;
       }
     }
     prevDiff = thisDiff;
     thisDiff = nextDiff;
-    nextDiff = pointer.hasNext() ? &pointer.next() : NULL;
+    nextDiff = pointer.hasNext() ? &pointer.next() : nullptr;
   }
   // If shifts were made, the diff needs reordering and another shift sweep.
   if (changes) {
@@ -1446,7 +1446,7 @@ int diff_match_patch::match_bitap(const QString &text, const QString &pattern,
   int bin_min, bin_mid;
   int bin_max = pattern.length() + text.length();
   int *rd;
-  int *last_rd = NULL;
+  int *last_rd = nullptr;
   for (int d = 0; d < pattern.length(); d++) {
     // Scan for the best match; each iteration allows for one more error.
     // Run a binary search to determine how far from 'loc' we can stray at

--- a/cpp/diff_match_patch.cpp
+++ b/cpp/diff_match_patch.cpp
@@ -1481,8 +1481,8 @@ int diff_match_patch::match_bitap(const QString &text, const QString &pattern,
         rd[j] = ((rd[j + 1] << 1) | 1) & charMatch;
       } else {
         // Subsequent passes: fuzzy match.
-        rd[j] = ((rd[j + 1] << 1) | 1) & charMatch |
-                (((last_rd[j + 1] | last_rd[j]) << 1) | 1) | last_rd[j + 1];
+        rd[j] = (((rd[j + 1] << 1) | 1) & charMatch) |
+                ((((last_rd[j + 1] | last_rd[j]) << 1) | 1) | last_rd[j + 1]);
       }
       if ((rd[j] & matchmask) != 0) {
         double score = match_bitapScore(d, j - 1, loc, pattern);

--- a/cpp/diff_match_patch.cpp
+++ b/cpp/diff_match_patch.cpp
@@ -65,7 +65,7 @@ QString Diff::strOperation(Operation op) {
 QString Diff::toString() const {
   QString prettyText = text;
   // Replace linebreaks with Pilcrow signs.
-  prettyText.replace('\n', L'\u00b6');
+  prettyText.replace('\n', QChar(L'\u00b6'));
   return QString("Diff(") + strOperation(operation) + QString(",\"") +
          prettyText + QString("\")");
 }

--- a/cpp/diff_match_patch.cpp
+++ b/cpp/diff_match_patch.cpp
@@ -1988,7 +1988,7 @@ QList<Patch> diff_match_patch::patch_fromText(const QString &textline) {
   if (textline.isEmpty()) {
     return patches;
   }
-  QStringList text = textline.split("\n", QString::SkipEmptyParts);
+  QStringList text = textline.split("\n", Qt::SkipEmptyParts);
   Patch patch;
   QRegularExpression patchHeader("^@@ -(\\d+),?(\\d*) \\+(\\d+),?(\\d*) @@$");
   char sign;

--- a/cpp/diff_match_patch.cpp
+++ b/cpp/diff_match_patch.cpp
@@ -23,10 +23,10 @@
 #include <algorithm>
 #include <limits>
 // Code known to compile and run with Qt 4.3 through Qt 4.7.
-#include <QtCore>
 #include <time.h>
-#include "diff_match_patch.h"
+#include <QtCore>
 
+#include "diff_match_patch.h"
 
 //////////////////////////
 //
@@ -34,20 +34,17 @@
 //
 //////////////////////////
 
-
 /**
  * Constructor.  Initializes the diff with the provided values.
  * @param operation One of Insert, Delete or Equal
  * @param text The text being applied
  */
-Diff::Diff(Operation _operation, const QString &_text) :
-  operation(_operation), text(_text) {
+Diff::Diff(Operation _operation, const QString &_text)
+    : operation(_operation), text(_text) {
   // Construct a diff with the specified operation and text.
 }
 
-Diff::Diff() {
-}
-
+Diff::Diff() {}
 
 QString Diff::strOperation(Operation op) {
   switch (op) {
@@ -69,8 +66,8 @@ QString Diff::toString() const {
   QString prettyText = text;
   // Replace linebreaks with Pilcrow signs.
   prettyText.replace('\n', L'\u00b6');
-  return QString("Diff(") + strOperation(operation) + QString(",\"")
-      + prettyText + QString("\")");
+  return QString("Diff(") + strOperation(operation) + QString(",\"") +
+         prettyText + QString("\")");
 }
 
 /**
@@ -82,10 +79,7 @@ bool Diff::operator==(const Diff &d) const {
   return (d.operation == this->operation) && (d.text == this->text);
 }
 
-bool Diff::operator!=(const Diff &d) const {
-  return !(operator == (d));
-}
-
+bool Diff::operator!=(const Diff &d) const { return !(operator==(d)); }
 
 /////////////////////////////////////////////
 //
@@ -93,23 +87,18 @@ bool Diff::operator!=(const Diff &d) const {
 //
 /////////////////////////////////////////////
 
-
 /**
  * Constructor.  Initializes with an empty list of diffs.
  */
-Patch::Patch() :
-  start1(0), start2(0),
-  length1(0), length2(0) {
-}
+Patch::Patch() : start1(0), start2(0), length1(0), length2(0) {}
 
 bool Patch::isNull() const {
-  if (start1 == 0 && start2 == 0 && length1 == 0 && length2 == 0
-      && diffs.size() == 0) {
+  if (start1 == 0 && start2 == 0 && length1 == 0 && length2 == 0 &&
+      diffs.size() == 0) {
     return true;
   }
   return false;
 }
-
 
 /**
  * Emulate GNU diff's format.
@@ -124,20 +113,19 @@ QString Patch::toString() {
   } else if (length1 == 1) {
     coords1 = QString::number(start1 + 1);
   } else {
-    coords1 = QString::number(start1 + 1) + QString(",")
-        + QString::number(length1);
+    coords1 =
+        QString::number(start1 + 1) + QString(",") + QString::number(length1);
   }
   if (length2 == 0) {
     coords2 = QString::number(start2) + QString(",0");
   } else if (length2 == 1) {
     coords2 = QString::number(start2 + 1);
   } else {
-    coords2 = QString::number(start2 + 1) + QString(",")
-        + QString::number(length2);
+    coords2 =
+        QString::number(start2 + 1) + QString(",") + QString::number(length2);
   }
   QString text;
-  text = QString("@@ -") + coords1 + QString(" +") + coords2
-      + QString(" @@\n");
+  text = QString("@@ -") + coords1 + QString(" +") + coords2 + QString(" @@\n");
   // Escape the body of the patch with %xx notation.
   foreach (Diff aDiff, diffs) {
     switch (aDiff.operation) {
@@ -151,13 +139,12 @@ QString Patch::toString() {
         text += QString(' ');
         break;
     }
-    text += QString(QUrl::toPercentEncoding(aDiff.text, " !~*'();/?:@&=+$,#"))
-        + QString("\n");
+    text += QString(QUrl::toPercentEncoding(aDiff.text, " !~*'();/?:@&=+$,#")) +
+            QString("\n");
   }
 
   return text;
 }
-
 
 /////////////////////////////////////////////
 //
@@ -165,16 +152,14 @@ QString Patch::toString() {
 //
 /////////////////////////////////////////////
 
-diff_match_patch::diff_match_patch() :
-  Diff_Timeout(1.0f),
-  Diff_EditCost(4),
-  Match_Threshold(0.5f),
-  Match_Distance(1000),
-  Patch_DeleteThreshold(0.5f),
-  Patch_Margin(4),
-  Match_MaxBits(32) {
-}
-
+diff_match_patch::diff_match_patch()
+    : Diff_Timeout(1.0f),
+      Diff_EditCost(4),
+      Match_Threshold(0.5f),
+      Match_Distance(1000),
+      Patch_DeleteThreshold(0.5f),
+      Patch_Margin(4),
+      Match_MaxBits(32) {}
 
 QList<Diff> diff_match_patch::diff_main(const QString &text1,
                                         const QString &text2) {
@@ -182,7 +167,7 @@ QList<Diff> diff_match_patch::diff_main(const QString &text1,
 }
 
 QList<Diff> diff_match_patch::diff_main(const QString &text1,
-    const QString &text2, bool checklines) {
+                                        const QString &text2, bool checklines) {
   // Set a deadline by which time the diff must be complete.
   clock_t deadline;
   if (Diff_Timeout <= 0) {
@@ -194,7 +179,8 @@ QList<Diff> diff_match_patch::diff_main(const QString &text1,
 }
 
 QList<Diff> diff_match_patch::diff_main(const QString &text1,
-    const QString &text2, bool checklines, clock_t deadline) {
+                                        const QString &text2, bool checklines,
+                                        clock_t deadline) {
   // Check for null inputs.
   if (text1.isNull() || text2.isNull()) {
     throw "Null inputs. (diff_main)";
@@ -237,9 +223,8 @@ QList<Diff> diff_match_patch::diff_main(const QString &text1,
   return diffs;
 }
 
-
 QList<Diff> diff_match_patch::diff_compute(QString text1, QString text2,
-    bool checklines, clock_t deadline) {
+                                           bool checklines, clock_t deadline) {
   QList<Diff> diffs;
 
   if (text1.isEmpty()) {
@@ -287,10 +272,10 @@ QList<Diff> diff_match_patch::diff_compute(QString text1, QString text2,
     const QString text2_b = hm[3];
     const QString mid_common = hm[4];
     // Send both pairs off for separate processing.
-    const QList<Diff> diffs_a = diff_main(text1_a, text2_a,
-                                          checklines, deadline);
-    const QList<Diff> diffs_b = diff_main(text1_b, text2_b,
-                                          checklines, deadline);
+    const QList<Diff> diffs_a =
+        diff_main(text1_a, text2_a, checklines, deadline);
+    const QList<Diff> diffs_b =
+        diff_main(text1_b, text2_b, checklines, deadline);
     // Merge the results.
     diffs = diffs_a;
     diffs.append(Diff(Equal, mid_common));
@@ -306,9 +291,8 @@ QList<Diff> diff_match_patch::diff_compute(QString text1, QString text2,
   return diff_bisect(text1, text2, deadline);
 }
 
-
 QList<Diff> diff_match_patch::diff_lineMode(QString text1, QString text2,
-    clock_t deadline) {
+                                            clock_t deadline) {
   // Scan the text on a line-by-line basis first.
   const QList<QVariant> b = diff_linesToChars(text1, text2);
   text1 = b[0].toString();
@@ -351,8 +335,8 @@ QList<Diff> diff_match_patch::diff_lineMode(QString text1, QString text2,
             pointer.previous();
             pointer.remove();
           }
-          foreach(Diff newDiff,
-              diff_main(text_delete, text_insert, false, deadline)) {
+          foreach (Diff newDiff,
+                   diff_main(text_delete, text_insert, false, deadline)) {
             pointer.insert(newDiff);
           }
         }
@@ -369,9 +353,9 @@ QList<Diff> diff_match_patch::diff_lineMode(QString text1, QString text2,
   return diffs;
 }
 
-
 QList<Diff> diff_match_patch::diff_bisect(const QString &text1,
-    const QString &text2, clock_t deadline) {
+                                          const QString &text2,
+                                          clock_t deadline) {
   // Cache the text lengths to prevent multiple calls.
   const int text1_length = text1.length();
   const int text2_length = text2.length();
@@ -412,8 +396,7 @@ QList<Diff> diff_match_patch::diff_bisect(const QString &text1,
         x1 = v1[k1_offset - 1] + 1;
       }
       int y1 = x1 - k1;
-      while (x1 < text1_length && y1 < text2_length
-          && text1[x1] == text2[y1]) {
+      while (x1 < text1_length && y1 < text2_length && text1[x1] == text2[y1]) {
         x1++;
         y1++;
       }
@@ -431,8 +414,8 @@ QList<Diff> diff_match_patch::diff_bisect(const QString &text1,
           int x2 = text1_length - v2[k2_offset];
           if (x1 >= x2) {
             // Overlap detected.
-            delete [] v1;
-            delete [] v2;
+            delete[] v1;
+            delete[] v2;
             return diff_bisectSplit(text1, text2, x1, y1, deadline);
           }
         }
@@ -449,8 +432,8 @@ QList<Diff> diff_match_patch::diff_bisect(const QString &text1,
         x2 = v2[k2_offset - 1] + 1;
       }
       int y2 = x2 - k2;
-      while (x2 < text1_length && y2 < text2_length
-          && text1[text1_length - x2 - 1] == text2[text2_length - y2 - 1]) {
+      while (x2 < text1_length && y2 < text2_length &&
+             text1[text1_length - x2 - 1] == text2[text2_length - y2 - 1]) {
         x2++;
         y2++;
       }
@@ -470,16 +453,16 @@ QList<Diff> diff_match_patch::diff_bisect(const QString &text1,
           x2 = text1_length - x2;
           if (x1 >= x2) {
             // Overlap detected.
-            delete [] v1;
-            delete [] v2;
+            delete[] v1;
+            delete[] v2;
             return diff_bisectSplit(text1, text2, x1, y1, deadline);
           }
         }
       }
     }
   }
-  delete [] v1;
-  delete [] v2;
+  delete[] v1;
+  delete[] v2;
   // Diff took too long and hit the deadline or
   // number of diffs equals number of characters, no commonality at all.
   QList<Diff> diffs;
@@ -489,7 +472,8 @@ QList<Diff> diff_match_patch::diff_bisect(const QString &text1,
 }
 
 QList<Diff> diff_match_patch::diff_bisectSplit(const QString &text1,
-    const QString &text2, int x, int y, clock_t deadline) {
+                                               const QString &text2, int x,
+                                               int y, clock_t deadline) {
   QString text1a = text1.left(x);
   QString text2a = text2.left(y);
   QString text1b = safeMid(text1, x);
@@ -523,7 +507,6 @@ QList<QVariant> diff_match_patch::diff_linesToChars(const QString &text1,
   return listRet;
 }
 
-
 QString diff_match_patch::diff_linesToCharsMunge(const QString &text,
                                                  QStringList &lineArray,
                                                  QMap<QString, int> &lineHash) {
@@ -553,8 +536,6 @@ QString diff_match_patch::diff_linesToCharsMunge(const QString &text,
   return chars;
 }
 
-
-
 void diff_match_patch::diff_charsToLines(QList<Diff> &diffs,
                                          const QStringList &lineArray) {
   // Qt has no mutable foreach construct.
@@ -569,7 +550,6 @@ void diff_match_patch::diff_charsToLines(QList<Diff> &diffs,
   }
 }
 
-
 int diff_match_patch::diff_commonPrefix(const QString &text1,
                                         const QString &text2) {
   // Performance analysis: http://neil.fraser.name/news/2007/10/09/
@@ -581,7 +561,6 @@ int diff_match_patch::diff_commonPrefix(const QString &text1,
   }
   return n;
 }
-
 
 int diff_match_patch::diff_commonSuffix(const QString &text1,
                                         const QString &text2) {
@@ -652,11 +631,11 @@ QStringList diff_match_patch::diff_halfMatch(const QString &text1,
   }
 
   // First check if the second quarter is the seed for a half-match.
-  const QStringList hm1 = diff_halfMatchI(longtext, shorttext,
-      (longtext.length() + 3) / 4);
+  const QStringList hm1 =
+      diff_halfMatchI(longtext, shorttext, (longtext.length() + 3) / 4);
   // Check again based on the third quarter.
-  const QStringList hm2 = diff_halfMatchI(longtext, shorttext,
-      (longtext.length() + 1) / 2);
+  const QStringList hm2 =
+      diff_halfMatchI(longtext, shorttext, (longtext.length() + 1) / 2);
   QStringList hm;
   if (hm1.isEmpty() && hm2.isEmpty()) {
     return QStringList();
@@ -679,10 +658,8 @@ QStringList diff_match_patch::diff_halfMatch(const QString &text1,
   }
 }
 
-
 QStringList diff_match_patch::diff_halfMatchI(const QString &longtext,
-                                              const QString &shorttext,
-                                              int i) {
+                                              const QString &shorttext, int i) {
   // Start with a 1/4 length substring at position i as a seed.
   const QString seed = safeMid(longtext, i, longtext.length() / 4);
   int j = -1;
@@ -690,13 +667,13 @@ QStringList diff_match_patch::diff_halfMatchI(const QString &longtext,
   QString best_longtext_a, best_longtext_b;
   QString best_shorttext_a, best_shorttext_b;
   while ((j = shorttext.indexOf(seed, j + 1)) != -1) {
-    const int prefixLength = diff_commonPrefix(safeMid(longtext, i),
-        safeMid(shorttext, j));
-    const int suffixLength = diff_commonSuffix(longtext.left(i),
-        shorttext.left(j));
+    const int prefixLength =
+        diff_commonPrefix(safeMid(longtext, i), safeMid(shorttext, j));
+    const int suffixLength =
+        diff_commonSuffix(longtext.left(i), shorttext.left(j));
     if (best_common.length() < suffixLength + prefixLength) {
-      best_common = safeMid(shorttext, j - suffixLength, suffixLength)
-          + safeMid(shorttext, j, prefixLength);
+      best_common = safeMid(shorttext, j - suffixLength, suffixLength) +
+                    safeMid(shorttext, j, prefixLength);
       best_longtext_a = longtext.left(i - suffixLength);
       best_longtext_b = safeMid(longtext, i + prefixLength);
       best_shorttext_a = shorttext.left(j - suffixLength);
@@ -706,13 +683,12 @@ QStringList diff_match_patch::diff_halfMatchI(const QString &longtext,
   if (best_common.length() * 2 >= longtext.length()) {
     QStringList listRet;
     listRet << best_longtext_a << best_longtext_b << best_shorttext_a
-        << best_shorttext_b << best_common;
+            << best_shorttext_b << best_common;
     return listRet;
   } else {
     return QStringList();
   }
 }
-
 
 void diff_match_patch::diff_cleanupSemantic(QList<Diff> &diffs) {
   if (diffs.isEmpty()) {
@@ -720,7 +696,7 @@ void diff_match_patch::diff_cleanupSemantic(QList<Diff> &diffs) {
   }
   bool changes = false;
   QStack<Diff> equalities;  // Stack of equalities.
-  QString lastequality;  // Always equal to equalities.lastElement().text
+  QString lastequality;     // Always equal to equalities.lastElement().text
   QMutableListIterator<Diff> pointer(diffs);
   // Number of characters that changed prior to the equality.
   int length_insertions1 = 0;
@@ -747,11 +723,11 @@ void diff_match_patch::diff_cleanupSemantic(QList<Diff> &diffs) {
       }
       // Eliminate an equality that is smaller or equal to the edits on both
       // sides of it.
-      if (!lastequality.isNull()
-          && (lastequality.length()
-              <= std::max(length_insertions1, length_deletions1))
-          && (lastequality.length()
-              <= std::max(length_insertions2, length_deletions2))) {
+      if (!lastequality.isNull() &&
+          (lastequality.length() <=
+           std::max(length_insertions1, length_deletions1)) &&
+          (lastequality.length() <=
+           std::max(length_insertions2, length_deletions2))) {
         // printf("Splitting: '%s'\n", qPrintable(lastequality));
         // Walk back to offending equality.
         while (*thisDiff != equalities.top()) {
@@ -815,8 +791,7 @@ void diff_match_patch::diff_cleanupSemantic(QList<Diff> &diffs) {
     }
   }
   while (thisDiff != NULL) {
-    if (prevDiff->operation == Delete &&
-        thisDiff->operation == Insert) {
+    if (prevDiff->operation == Delete && thisDiff->operation == Insert) {
       QString deletion = prevDiff->text;
       QString insertion = thisDiff->text;
       int overlap_length1 = diff_commonOverlap(deletion, insertion);
@@ -827,8 +802,7 @@ void diff_match_patch::diff_cleanupSemantic(QList<Diff> &diffs) {
           // Overlap found.  Insert an equality and trim the surrounding edits.
           pointer.previous();
           pointer.insert(Diff(Equal, insertion.left(overlap_length1)));
-          prevDiff->text =
-              deletion.left(deletion.length() - overlap_length1);
+          prevDiff->text = deletion.left(deletion.length() - overlap_length1);
           thisDiff->text = safeMid(insertion, overlap_length1);
           // pointer.insert inserts the element before the cursor, so there is
           // no need to step past the new element.
@@ -841,8 +815,7 @@ void diff_match_patch::diff_cleanupSemantic(QList<Diff> &diffs) {
           pointer.previous();
           pointer.insert(Diff(Equal, deletion.left(overlap_length2)));
           prevDiff->operation = Insert;
-          prevDiff->text =
-              insertion.left(insertion.length() - overlap_length2);
+          prevDiff->text = insertion.left(insertion.length() - overlap_length2);
           thisDiff->operation = Delete;
           thisDiff->text = safeMid(deletion, overlap_length2);
           // pointer.insert inserts the element before the cursor, so there is
@@ -855,7 +828,6 @@ void diff_match_patch::diff_cleanupSemantic(QList<Diff> &diffs) {
     thisDiff = pointer.hasNext() ? &pointer.next() : NULL;
   }
 }
-
 
 void diff_match_patch::diff_cleanupSemanticLossless(QList<Diff> &diffs) {
   QString equality1, edit, equality2;
@@ -871,72 +843,70 @@ void diff_match_patch::diff_cleanupSemanticLossless(QList<Diff> &diffs) {
 
   // Intentionally ignore the first and last element (don't need checking).
   while (nextDiff != NULL) {
-    if (prevDiff->operation == Equal &&
-      nextDiff->operation == Equal) {
-        // This is a single edit surrounded by equalities.
-        equality1 = prevDiff->text;
-        edit = thisDiff->text;
-        equality2 = nextDiff->text;
+    if (prevDiff->operation == Equal && nextDiff->operation == Equal) {
+      // This is a single edit surrounded by equalities.
+      equality1 = prevDiff->text;
+      edit = thisDiff->text;
+      equality2 = nextDiff->text;
 
-        // First, shift the edit as far left as possible.
-        commonOffset = diff_commonSuffix(equality1, edit);
-        if (commonOffset != 0) {
-          commonString = safeMid(edit, edit.length() - commonOffset);
-          equality1 = equality1.left(equality1.length() - commonOffset);
-          edit = commonString + edit.left(edit.length() - commonOffset);
-          equality2 = commonString + equality2;
-        }
+      // First, shift the edit as far left as possible.
+      commonOffset = diff_commonSuffix(equality1, edit);
+      if (commonOffset != 0) {
+        commonString = safeMid(edit, edit.length() - commonOffset);
+        equality1 = equality1.left(equality1.length() - commonOffset);
+        edit = commonString + edit.left(edit.length() - commonOffset);
+        equality2 = commonString + equality2;
+      }
 
-        // Second, step character by character right, looking for the best fit.
-        bestEquality1 = equality1;
-        bestEdit = edit;
-        bestEquality2 = equality2;
-        bestScore = diff_cleanupSemanticScore(equality1, edit)
-            + diff_cleanupSemanticScore(edit, equality2);
-        while (!edit.isEmpty() && !equality2.isEmpty()
-            && edit[0] == equality2[0]) {
-          equality1 += edit[0];
-          edit = safeMid(edit, 1) + equality2[0];
-          equality2 = safeMid(equality2, 1);
-          score = diff_cleanupSemanticScore(equality1, edit)
-              + diff_cleanupSemanticScore(edit, equality2);
-          // The >= encourages trailing rather than leading whitespace on edits.
-          if (score >= bestScore) {
-            bestScore = score;
-            bestEquality1 = equality1;
-            bestEdit = edit;
-            bestEquality2 = equality2;
-          }
+      // Second, step character by character right, looking for the best fit.
+      bestEquality1 = equality1;
+      bestEdit = edit;
+      bestEquality2 = equality2;
+      bestScore = diff_cleanupSemanticScore(equality1, edit) +
+                  diff_cleanupSemanticScore(edit, equality2);
+      while (!edit.isEmpty() && !equality2.isEmpty() &&
+             edit[0] == equality2[0]) {
+        equality1 += edit[0];
+        edit = safeMid(edit, 1) + equality2[0];
+        equality2 = safeMid(equality2, 1);
+        score = diff_cleanupSemanticScore(equality1, edit) +
+                diff_cleanupSemanticScore(edit, equality2);
+        // The >= encourages trailing rather than leading whitespace on edits.
+        if (score >= bestScore) {
+          bestScore = score;
+          bestEquality1 = equality1;
+          bestEdit = edit;
+          bestEquality2 = equality2;
         }
+      }
 
-        if (prevDiff->text != bestEquality1) {
-          // We have an improvement, save it back to the diff.
-          if (!bestEquality1.isEmpty()) {
-            prevDiff->text = bestEquality1;
-          } else {
-            pointer.previous();  // Walk past nextDiff.
-            pointer.previous();  // Walk past thisDiff.
-            pointer.previous();  // Walk past prevDiff.
-            pointer.remove();  // Delete prevDiff.
-            pointer.next();  // Walk past thisDiff.
-            pointer.next();  // Walk past nextDiff.
-          }
-          thisDiff->text = bestEdit;
-          if (!bestEquality2.isEmpty()) {
-            nextDiff->text = bestEquality2;
-          } else {
-            pointer.remove(); // Delete nextDiff.
-            nextDiff = thisDiff;
-            thisDiff = prevDiff;
-          }
+      if (prevDiff->text != bestEquality1) {
+        // We have an improvement, save it back to the diff.
+        if (!bestEquality1.isEmpty()) {
+          prevDiff->text = bestEquality1;
+        } else {
+          pointer.previous();  // Walk past nextDiff.
+          pointer.previous();  // Walk past thisDiff.
+          pointer.previous();  // Walk past prevDiff.
+          pointer.remove();    // Delete prevDiff.
+          pointer.next();      // Walk past thisDiff.
+          pointer.next();      // Walk past nextDiff.
         }
+        thisDiff->text = bestEdit;
+        if (!bestEquality2.isEmpty()) {
+          nextDiff->text = bestEquality2;
+        } else {
+          pointer.remove();  // Delete nextDiff.
+          nextDiff = thisDiff;
+          thisDiff = prevDiff;
+        }
+      }
     }
     prevDiff = thisDiff;
     thisDiff = nextDiff;
     nextDiff = pointer.hasNext() ? &pointer.next() : NULL;
   }
 }
-
 
 int diff_match_patch::diff_cleanupSemanticScore(const QString &one,
                                                 const QString &two) {
@@ -980,11 +950,9 @@ int diff_match_patch::diff_cleanupSemanticScore(const QString &one,
   return 0;
 }
 
-
 // Define some regex patterns for matching boundaries.
 QRegExp diff_match_patch::BLANKLINEEND = QRegExp("\\n\\r?\\n$");
 QRegExp diff_match_patch::BLANKLINESTART = QRegExp("^\\r?\\n\\r?\\n");
-
 
 void diff_match_patch::diff_cleanupEfficiency(QList<Diff> &diffs) {
   if (diffs.isEmpty()) {
@@ -992,7 +960,7 @@ void diff_match_patch::diff_cleanupEfficiency(QList<Diff> &diffs) {
   }
   bool changes = false;
   QStack<Diff> equalities;  // Stack of equalities.
-  QString lastequality;  // Always equal to equalities.lastElement().text
+  QString lastequality;     // Always equal to equalities.lastElement().text
   QMutableListIterator<Diff> pointer(diffs);
   // Is there an insertion operation before the last equality.
   bool pre_ins = false;
@@ -1030,18 +998,18 @@ void diff_match_patch::diff_cleanupEfficiency(QList<Diff> &diffs) {
         post_ins = true;
       }
       /*
-      * Five types to be split:
-      * <ins>A</ins><del>B</del>XY<ins>C</ins><del>D</del>
-      * <ins>A</ins>X<ins>C</ins><del>D</del>
-      * <ins>A</ins><del>B</del>X<ins>C</ins>
-      * <ins>A</del>X<ins>C</ins><del>D</del>
-      * <ins>A</ins><del>B</del>X<del>C</del>
-      */
-      if (!lastequality.isNull()
-          && ((pre_ins && pre_del && post_ins && post_del)
-          || ((lastequality.length() < Diff_EditCost / 2)
-          && ((pre_ins ? 1 : 0) + (pre_del ? 1 : 0)
-          + (post_ins ? 1 : 0) + (post_del ? 1 : 0)) == 3))) {
+       * Five types to be split:
+       * <ins>A</ins><del>B</del>XY<ins>C</ins><del>D</del>
+       * <ins>A</ins>X<ins>C</ins><del>D</del>
+       * <ins>A</ins><del>B</del>X<ins>C</ins>
+       * <ins>A</del>X<ins>C</ins><del>D</del>
+       * <ins>A</ins><del>B</del>X<del>C</del>
+       */
+      if (!lastequality.isNull() &&
+          ((pre_ins && pre_del && post_ins && post_del) ||
+           ((lastequality.length() < Diff_EditCost / 2) &&
+            ((pre_ins ? 1 : 0) + (pre_del ? 1 : 0) + (post_ins ? 1 : 0) +
+             (post_del ? 1 : 0)) == 3))) {
         // printf("Splitting: '%s'\n", qPrintable(lastequality));
         // Walk back to offending equality.
         while (*thisDiff != equalities.top()) {
@@ -1092,7 +1060,6 @@ void diff_match_patch::diff_cleanupEfficiency(QList<Diff> &diffs) {
     diff_cleanupMerge(diffs);
   }
 }
-
 
 void diff_match_patch::diff_cleanupMerge(QList<Diff> &diffs) {
   diffs.append(Diff(Equal, ""));  // Add a dummy entry at the end.
@@ -1150,12 +1117,13 @@ void diff_match_patch::diff_cleanupMerge(QList<Diff> &diffs) {
             commonlength = diff_commonSuffix(text_insert, text_delete);
             if (commonlength != 0) {
               thisDiff = &pointer.next();
-              thisDiff->text = safeMid(text_insert, text_insert.length()
-                  - commonlength) + thisDiff->text;
-              text_insert = text_insert.left(text_insert.length()
-                  - commonlength);
-              text_delete = text_delete.left(text_delete.length()
-                  - commonlength);
+              thisDiff->text =
+                  safeMid(text_insert, text_insert.length() - commonlength) +
+                  thisDiff->text;
+              text_insert =
+                  text_insert.left(text_insert.length() - commonlength);
+              text_delete =
+                  text_delete.left(text_delete.length() - commonlength);
               pointer.previous();
             }
           }
@@ -1182,18 +1150,18 @@ void diff_match_patch::diff_cleanupMerge(QList<Diff> &diffs) {
         text_insert = "";
         prevEqual = thisDiff;
         break;
-      }
-      thisDiff = pointer.hasNext() ? &pointer.next() : NULL;
+    }
+    thisDiff = pointer.hasNext() ? &pointer.next() : NULL;
   }
   if (diffs.back().text.isEmpty()) {
     diffs.removeLast();  // Remove the dummy entry at the end.
   }
 
   /*
-  * Second pass: look for single edits surrounded on both sides by equalities
-  * which can be shifted sideways to eliminate an equality.
-  * e.g: A<ins>BA</ins>C -> <ins>AB</ins>AC
-  */
+   * Second pass: look for single edits surrounded on both sides by equalities
+   * which can be shifted sideways to eliminate an equality.
+   * e.g: A<ins>BA</ins>C -> <ins>AB</ins>AC
+   */
   bool changes = false;
   // Create a new iterator at the start.
   // (As opposed to walking the current one back.)
@@ -1204,32 +1172,31 @@ void diff_match_patch::diff_cleanupMerge(QList<Diff> &diffs) {
 
   // Intentionally ignore the first and last element (don't need checking).
   while (nextDiff != NULL) {
-    if (prevDiff->operation == Equal &&
-      nextDiff->operation == Equal) {
-        // This is a single edit surrounded by equalities.
-        if (thisDiff->text.endsWith(prevDiff->text)) {
-          // Shift the edit over the previous equality.
-          thisDiff->text = prevDiff->text
-              + thisDiff->text.left(thisDiff->text.length()
-              - prevDiff->text.length());
-          nextDiff->text = prevDiff->text + nextDiff->text;
-          pointer.previous();  // Walk past nextDiff.
-          pointer.previous();  // Walk past thisDiff.
-          pointer.previous();  // Walk past prevDiff.
-          pointer.remove();  // Delete prevDiff.
-          pointer.next();  // Walk past thisDiff.
-          thisDiff = &pointer.next();  // Walk past nextDiff.
-          nextDiff = pointer.hasNext() ? &pointer.next() : NULL;
-          changes = true;
-        } else if (thisDiff->text.startsWith(nextDiff->text)) {
-          // Shift the edit over the next equality.
-          prevDiff->text += nextDiff->text;
-          thisDiff->text = safeMid(thisDiff->text, nextDiff->text.length())
-              + nextDiff->text;
-          pointer.remove(); // Delete nextDiff.
-          nextDiff = pointer.hasNext() ? &pointer.next() : NULL;
-          changes = true;
-        }
+    if (prevDiff->operation == Equal && nextDiff->operation == Equal) {
+      // This is a single edit surrounded by equalities.
+      if (thisDiff->text.endsWith(prevDiff->text)) {
+        // Shift the edit over the previous equality.
+        thisDiff->text =
+            prevDiff->text + thisDiff->text.left(thisDiff->text.length() -
+                                                 prevDiff->text.length());
+        nextDiff->text = prevDiff->text + nextDiff->text;
+        pointer.previous();          // Walk past nextDiff.
+        pointer.previous();          // Walk past thisDiff.
+        pointer.previous();          // Walk past prevDiff.
+        pointer.remove();            // Delete prevDiff.
+        pointer.next();              // Walk past thisDiff.
+        thisDiff = &pointer.next();  // Walk past nextDiff.
+        nextDiff = pointer.hasNext() ? &pointer.next() : NULL;
+        changes = true;
+      } else if (thisDiff->text.startsWith(nextDiff->text)) {
+        // Shift the edit over the next equality.
+        prevDiff->text += nextDiff->text;
+        thisDiff->text =
+            safeMid(thisDiff->text, nextDiff->text.length()) + nextDiff->text;
+        pointer.remove();  // Delete nextDiff.
+        nextDiff = pointer.hasNext() ? &pointer.next() : NULL;
+        changes = true;
+      }
     }
     prevDiff = thisDiff;
     thisDiff = nextDiff;
@@ -1241,14 +1208,13 @@ void diff_match_patch::diff_cleanupMerge(QList<Diff> &diffs) {
   }
 }
 
-
 int diff_match_patch::diff_xIndex(const QList<Diff> &diffs, int loc) {
   int chars1 = 0;
   int chars2 = 0;
   int last_chars1 = 0;
   int last_chars2 = 0;
   Diff lastDiff;
-  foreach(Diff aDiff, diffs) {
+  foreach (Diff aDiff, diffs) {
     if (aDiff.operation != Insert) {
       // Equality or deletion.
       chars1 += aDiff.text.length();
@@ -1273,22 +1239,23 @@ int diff_match_patch::diff_xIndex(const QList<Diff> &diffs, int loc) {
   return last_chars2 + (loc - last_chars1);
 }
 
-
 QString diff_match_patch::diff_prettyHtml(const QList<Diff> &diffs) {
   QString html;
   QString text;
-  foreach(Diff aDiff, diffs) {
+  foreach (Diff aDiff, diffs) {
     text = aDiff.text;
-    text.replace("&", "&amp;").replace("<", "&lt;")
-        .replace(">", "&gt;").replace("\n", "&para;<br>");
+    text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\n", "&para;<br>");
     switch (aDiff.operation) {
       case Insert:
-        html += QString("<ins style=\"background:#e6ffe6;\">") + text
-            + QString("</ins>");
+        html += QString("<ins style=\"background:#e6ffe6;\">") + text +
+                QString("</ins>");
         break;
       case Delete:
-        html += QString("<del style=\"background:#ffe6e6;\">") + text
-            + QString("</del>");
+        html += QString("<del style=\"background:#ffe6e6;\">") + text +
+                QString("</del>");
         break;
       case Equal:
         html += QString("<span>") + text + QString("</span>");
@@ -1298,10 +1265,9 @@ QString diff_match_patch::diff_prettyHtml(const QList<Diff> &diffs) {
   return html;
 }
 
-
 QString diff_match_patch::diff_text1(const QList<Diff> &diffs) {
   QString text;
-  foreach(Diff aDiff, diffs) {
+  foreach (Diff aDiff, diffs) {
     if (aDiff.operation != Insert) {
       text += aDiff.text;
     }
@@ -1309,10 +1275,9 @@ QString diff_match_patch::diff_text1(const QList<Diff> &diffs) {
   return text;
 }
 
-
 QString diff_match_patch::diff_text2(const QList<Diff> &diffs) {
   QString text;
-  foreach(Diff aDiff, diffs) {
+  foreach (Diff aDiff, diffs) {
     if (aDiff.operation != Delete) {
       text += aDiff.text;
     }
@@ -1320,12 +1285,11 @@ QString diff_match_patch::diff_text2(const QList<Diff> &diffs) {
   return text;
 }
 
-
 int diff_match_patch::diff_levenshtein(const QList<Diff> &diffs) {
   int levenshtein = 0;
   int insertions = 0;
   int deletions = 0;
-  foreach(Diff aDiff, diffs) {
+  foreach (Diff aDiff, diffs) {
     switch (aDiff.operation) {
       case Insert:
         insertions += aDiff.text.length();
@@ -1345,24 +1309,23 @@ int diff_match_patch::diff_levenshtein(const QList<Diff> &diffs) {
   return levenshtein;
 }
 
-
 QString diff_match_patch::diff_toDelta(const QList<Diff> &diffs) {
   QString text;
-  foreach(Diff aDiff, diffs) {
+  foreach (Diff aDiff, diffs) {
     switch (aDiff.operation) {
       case Insert: {
-        QString encoded = QString(QUrl::toPercentEncoding(aDiff.text,
-            " !~*'();/?:@&=+$,#"));
+        QString encoded =
+            QString(QUrl::toPercentEncoding(aDiff.text, " !~*'();/?:@&=+$,#"));
         text += QString("+") + encoded + QString("\t");
         break;
       }
       case Delete:
-        text += QString("-") + QString::number(aDiff.text.length())
-            + QString("\t");
+        text +=
+            QString("-") + QString::number(aDiff.text.length()) + QString("\t");
         break;
       case Equal:
-        text += QString("=") + QString::number(aDiff.text.length())
-            + QString("\t");
+        text +=
+            QString("=") + QString::number(aDiff.text.length()) + QString("\t");
         break;
     }
   }
@@ -1373,13 +1336,12 @@ QString diff_match_patch::diff_toDelta(const QList<Diff> &diffs) {
   return text;
 }
 
-
 QList<Diff> diff_match_patch::diff_fromDelta(const QString &text1,
                                              const QString &delta) {
   QList<Diff> diffs;
   int pointer = 0;  // Cursor in text1
   QStringList tokens = delta.split("\t");
-  foreach(QString token, tokens) {
+  foreach (QString token, tokens) {
     if (token.isEmpty()) {
       // Blank tokens are ok (from a trailing \t).
       continue;
@@ -1417,14 +1379,13 @@ QList<Diff> diff_match_patch::diff_fromDelta(const QString &text1,
   }
   if (pointer != text1.length()) {
     throw QString("Delta length (%1) smaller than source text length (%2)")
-        .arg(pointer).arg(text1.length());
+        .arg(pointer)
+        .arg(text1.length());
   }
   return diffs;
 }
 
-
-  //  MATCH FUNCTIONS
-
+//  MATCH FUNCTIONS
 
 int diff_match_patch::match_main(const QString &text, const QString &pattern,
                                  int loc) {
@@ -1440,8 +1401,8 @@ int diff_match_patch::match_main(const QString &text, const QString &pattern,
   } else if (text.isEmpty()) {
     // Nothing to match.
     return -1;
-  } else if (loc + pattern.length() <= text.length()
-      && safeMid(text, loc, pattern.length()) == pattern) {
+  } else if (loc + pattern.length() <= text.length() &&
+             safeMid(text, loc, pattern.length()) == pattern) {
     // Perfect match at the perfect spot!  (Includes case of null pattern)
     return loc;
   } else {
@@ -1449,7 +1410,6 @@ int diff_match_patch::match_main(const QString &text, const QString &pattern,
     return match_bitap(text, pattern, loc);
   }
 }
-
 
 int diff_match_patch::match_bitap(const QString &text, const QString &pattern,
                                   int loc) {
@@ -1465,13 +1425,13 @@ int diff_match_patch::match_bitap(const QString &text, const QString &pattern,
   // Is there a nearby exact match? (speedup)
   int best_loc = text.indexOf(pattern, loc);
   if (best_loc != -1) {
-    score_threshold = std::min(match_bitapScore(0, best_loc, loc, pattern),
-        score_threshold);
+    score_threshold =
+        std::min(match_bitapScore(0, best_loc, loc, pattern), score_threshold);
     // What about in the other direction? (speedup)
     best_loc = text.lastIndexOf(pattern, loc + pattern.length());
     if (best_loc != -1) {
       score_threshold = std::min(match_bitapScore(0, best_loc, loc, pattern),
-          score_threshold);
+                                 score_threshold);
     }
   }
 
@@ -1490,8 +1450,7 @@ int diff_match_patch::match_bitap(const QString &text, const QString &pattern,
     bin_min = 0;
     bin_mid = bin_max;
     while (bin_min < bin_mid) {
-      if (match_bitapScore(d, loc + bin_mid, loc, pattern)
-          <= score_threshold) {
+      if (match_bitapScore(d, loc + bin_mid, loc, pattern) <= score_threshold) {
         bin_min = bin_mid;
       } else {
         bin_max = bin_mid;
@@ -1518,9 +1477,8 @@ int diff_match_patch::match_bitap(const QString &text, const QString &pattern,
         rd[j] = ((rd[j + 1] << 1) | 1) & charMatch;
       } else {
         // Subsequent passes: fuzzy match.
-        rd[j] = ((rd[j + 1] << 1) | 1) & charMatch
-            | (((last_rd[j + 1] | last_rd[j]) << 1) | 1)
-            | last_rd[j + 1];
+        rd[j] = ((rd[j + 1] << 1) | 1) & charMatch |
+                (((last_rd[j + 1] | last_rd[j]) << 1) | 1) | last_rd[j + 1];
       }
       if ((rd[j] & matchmask) != 0) {
         double score = match_bitapScore(d, j - 1, loc, pattern);
@@ -1544,26 +1502,24 @@ int diff_match_patch::match_bitap(const QString &text, const QString &pattern,
       // No hope for a (better) match at greater error levels.
       break;
     }
-    delete [] last_rd;
+    delete[] last_rd;
     last_rd = rd;
   }
-  delete [] last_rd;
-  delete [] rd;
+  delete[] last_rd;
+  delete[] rd;
   return best_loc;
 }
 
-
 double diff_match_patch::match_bitapScore(int e, int x, int loc,
                                           const QString &pattern) {
-  const float accuracy = static_cast<float> (e) / pattern.length();
+  const float accuracy = static_cast<float>(e) / pattern.length();
   const int proximity = qAbs(loc - x);
   if (Match_Distance == 0) {
     // Dodge divide by zero error.
     return proximity == 0 ? accuracy : 1.0;
   }
-  return accuracy + (proximity / static_cast<float> (Match_Distance));
+  return accuracy + (proximity / static_cast<float>(Match_Distance));
 }
-
 
 QMap<QChar, int> diff_match_patch::match_alphabet(const QString &pattern) {
   QMap<QChar, int> s;
@@ -1579,9 +1535,7 @@ QMap<QChar, int> diff_match_patch::match_alphabet(const QString &pattern) {
   return s;
 }
 
-
 //  PATCH FUNCTIONS
-
 
 void diff_match_patch::patch_addContext(Patch &patch, const QString &text) {
   if (text.isEmpty()) {
@@ -1592,26 +1546,28 @@ void diff_match_patch::patch_addContext(Patch &patch, const QString &text) {
 
   // Look for the first and last matches of pattern in text.  If two different
   // matches are found, increase the pattern length.
-  while (text.indexOf(pattern) != text.lastIndexOf(pattern)
-      && pattern.length() < Match_MaxBits - Patch_Margin - Patch_Margin) {
+  while (text.indexOf(pattern) != text.lastIndexOf(pattern) &&
+         pattern.length() < Match_MaxBits - Patch_Margin - Patch_Margin) {
     padding += Patch_Margin;
-    pattern = safeMid(text, std::max(0, patch.start2 - padding),
-        std::min(text.length(), patch.start2 + patch.length1 + padding)
-        - std::max(0, patch.start2 - padding));
+    pattern = safeMid(
+        text, std::max(0, patch.start2 - padding),
+        std::min(text.length(), patch.start2 + patch.length1 + padding) -
+            std::max(0, patch.start2 - padding));
   }
   // Add one chunk for good luck.
   padding += Patch_Margin;
 
   // Add the prefix.
   QString prefix = safeMid(text, std::max(0, patch.start2 - padding),
-      patch.start2 - std::max(0, patch.start2 - padding));
+                           patch.start2 - std::max(0, patch.start2 - padding));
   if (!prefix.isEmpty()) {
     patch.diffs.prepend(Diff(Equal, prefix));
   }
   // Add the suffix.
-  QString suffix = safeMid(text, patch.start2 + patch.length1,
-      std::min(text.length(), patch.start2 + patch.length1 + padding)
-      - (patch.start2 + patch.length1));
+  QString suffix =
+      safeMid(text, patch.start2 + patch.length1,
+              std::min(text.length(), patch.start2 + patch.length1 + padding) -
+                  (patch.start2 + patch.length1));
   if (!suffix.isEmpty()) {
     patch.diffs.append(Diff(Equal, suffix));
   }
@@ -1623,7 +1579,6 @@ void diff_match_patch::patch_addContext(Patch &patch, const QString &text) {
   patch.length1 += prefix.length() + suffix.length();
   patch.length2 += prefix.length() + suffix.length();
 }
-
 
 QList<Patch> diff_match_patch::patch_make(const QString &text1,
                                           const QString &text2) {
@@ -1642,13 +1597,11 @@ QList<Patch> diff_match_patch::patch_make(const QString &text1,
   return patch_make(text1, diffs);
 }
 
-
 QList<Patch> diff_match_patch::patch_make(const QList<Diff> &diffs) {
   // No origin string provided, compute our own.
   const QString text1 = diff_text1(diffs);
   return patch_make(text1, diffs);
 }
-
 
 QList<Patch> diff_match_patch::patch_make(const QString &text1,
                                           const QString &text2,
@@ -1658,7 +1611,6 @@ QList<Patch> diff_match_patch::patch_make(const QString &text1,
 
   Q_UNUSED(text2)
 }
-
 
 QList<Patch> diff_match_patch::patch_make(const QString &text1,
                                           const QList<Diff> &diffs) {
@@ -1679,7 +1631,7 @@ QList<Patch> diff_match_patch::patch_make(const QString &text1,
   // context info.
   QString prepatch_text = text1;
   QString postpatch_text = text1;
-  foreach(Diff aDiff, diffs) {
+  foreach (Diff aDiff, diffs) {
     if (patch.diffs.isEmpty() && aDiff.operation != Equal) {
       // A new patch starts here.
       patch.start1 = char_count1;
@@ -1690,18 +1642,19 @@ QList<Patch> diff_match_patch::patch_make(const QString &text1,
       case Insert:
         patch.diffs.append(aDiff);
         patch.length2 += aDiff.text.length();
-        postpatch_text = postpatch_text.left(char_count2)
-            + aDiff.text + safeMid(postpatch_text, char_count2);
+        postpatch_text = postpatch_text.left(char_count2) + aDiff.text +
+                         safeMid(postpatch_text, char_count2);
         break;
       case Delete:
         patch.length1 += aDiff.text.length();
         patch.diffs.append(aDiff);
-        postpatch_text = postpatch_text.left(char_count2)
-            + safeMid(postpatch_text, char_count2 + aDiff.text.length());
+        postpatch_text =
+            postpatch_text.left(char_count2) +
+            safeMid(postpatch_text, char_count2 + aDiff.text.length());
         break;
       case Equal:
-        if (aDiff.text.length() <= 2 * Patch_Margin
-            && !patch.diffs.isEmpty() && !(aDiff == diffs.back())) {
+        if (aDiff.text.length() <= 2 * Patch_Margin && !patch.diffs.isEmpty() &&
+            !(aDiff == diffs.back())) {
           // Small equality inside a patch.
           patch.diffs.append(aDiff);
           patch.length1 += aDiff.text.length();
@@ -1742,12 +1695,11 @@ QList<Patch> diff_match_patch::patch_make(const QString &text1,
   return patches;
 }
 
-
 QList<Patch> diff_match_patch::patch_deepCopy(QList<Patch> &patches) {
   QList<Patch> patchesCopy;
-  foreach(Patch aPatch, patches) {
+  foreach (Patch aPatch, patches) {
     Patch patchCopy = Patch();
-    foreach(Diff aDiff, aPatch.diffs) {
+    foreach (Diff aDiff, aPatch.diffs) {
       Diff diffCopy = Diff(aDiff.operation, aDiff.text);
       patchCopy.diffs.append(diffCopy);
     }
@@ -1760,12 +1712,11 @@ QList<Patch> diff_match_patch::patch_deepCopy(QList<Patch> &patches) {
   return patchesCopy;
 }
 
-
 QPair<QString, QVector<bool> > diff_match_patch::patch_apply(
     QList<Patch> &patches, const QString &sourceText) {
   QString text = sourceText;  // Copy to preserve original.
   if (patches.isEmpty()) {
-    return QPair<QString,QVector<bool> >(text, QVector<bool>(0));
+    return QPair<QString, QVector<bool> >(text, QVector<bool>(0));
   }
 
   // Deep copy the patches so that no changes are made to originals.
@@ -1782,7 +1733,7 @@ QPair<QString, QVector<bool> > diff_match_patch::patch_apply(
   // has an effective expected position of 22.
   int delta = 0;
   QVector<bool> results(patchesCopy.size());
-  foreach(Patch aPatch, patchesCopy) {
+  foreach (Patch aPatch, patchesCopy) {
     int expected_loc = aPatch.start2 + delta;
     QString text1 = diff_text1(aPatch.diffs);
     int start_loc;
@@ -1793,7 +1744,7 @@ QPair<QString, QVector<bool> > diff_match_patch::patch_apply(
       start_loc = match_main(text, text1.left(Match_MaxBits), expected_loc);
       if (start_loc != -1) {
         end_loc = match_main(text, text1.right(Match_MaxBits),
-            expected_loc + text1.length() - Match_MaxBits);
+                             expected_loc + text1.length() - Match_MaxBits);
         if (end_loc == -1 || start_loc >= end_loc) {
           // Can't find valid trailing context.  Drop this patch.
           start_loc = -1;
@@ -1819,32 +1770,34 @@ QPair<QString, QVector<bool> > diff_match_patch::patch_apply(
       }
       if (text1 == text2) {
         // Perfect match, just shove the replacement text in.
-        text = text.left(start_loc) + diff_text2(aPatch.diffs)
-            + safeMid(text, start_loc + text1.length());
+        text = text.left(start_loc) + diff_text2(aPatch.diffs) +
+               safeMid(text, start_loc + text1.length());
       } else {
         // Imperfect match.  Run a diff to get a framework of equivalent
         // indices.
         QList<Diff> diffs = diff_main(text1, text2, false);
-        if (text1.length() > Match_MaxBits
-            && diff_levenshtein(diffs) / static_cast<float> (text1.length())
-            > Patch_DeleteThreshold) {
+        if (text1.length() > Match_MaxBits &&
+            diff_levenshtein(diffs) / static_cast<float>(text1.length()) >
+                Patch_DeleteThreshold) {
           // The end points match, but the content is unacceptably bad.
           results[x] = false;
         } else {
           diff_cleanupSemanticLossless(diffs);
           int index1 = 0;
-          foreach(Diff aDiff, aPatch.diffs) {
+          foreach (Diff aDiff, aPatch.diffs) {
             if (aDiff.operation != Equal) {
               int index2 = diff_xIndex(diffs, index1);
               if (aDiff.operation == Insert) {
                 // Insertion
-                text = text.left(start_loc + index2) + aDiff.text
-                    + safeMid(text, start_loc + index2);
+                text = text.left(start_loc + index2) + aDiff.text +
+                       safeMid(text, start_loc + index2);
               } else if (aDiff.operation == Delete) {
                 // Deletion
-                text = text.left(start_loc + index2)
-                    + safeMid(text, start_loc + diff_xIndex(diffs,
-                    index1 + aDiff.text.length()));
+                text =
+                    text.left(start_loc + index2) +
+                    safeMid(text, start_loc +
+                                      diff_xIndex(
+                                          diffs, index1 + aDiff.text.length()));
               }
             }
             if (aDiff.operation != Delete) {
@@ -1857,11 +1810,10 @@ QPair<QString, QVector<bool> > diff_match_patch::patch_apply(
     x++;
   }
   // Strip the padding off.
-  text = safeMid(text, nullPadding.length(), text.length()
-      - 2 * nullPadding.length());
+  text = safeMid(text, nullPadding.length(),
+                 text.length() - 2 * nullPadding.length());
   return QPair<QString, QVector<bool> >(text, results);
 }
-
 
 QString diff_match_patch::patch_addPadding(QList<Patch> &patches) {
   short paddingLength = Patch_Margin;
@@ -1893,7 +1845,8 @@ QString diff_match_patch::patch_addPadding(QList<Patch> &patches) {
     Diff &firstDiff = firstPatchDiffs.first();
     int extraLength = paddingLength - firstDiff.text.length();
     firstDiff.text = safeMid(nullPadding, firstDiff.text.length(),
-        paddingLength - firstDiff.text.length()) + firstDiff.text;
+                             paddingLength - firstDiff.text.length()) +
+                     firstDiff.text;
     firstPatch.start1 -= extraLength;
     firstPatch.start2 -= extraLength;
     firstPatch.length1 += extraLength;
@@ -1919,7 +1872,6 @@ QString diff_match_patch::patch_addPadding(QList<Patch> &patches) {
 
   return nullPadding;
 }
-
 
 void diff_match_patch::patch_splitMax(QList<Patch> &patches) {
   short patch_size = Match_MaxBits;
@@ -1956,8 +1908,8 @@ void diff_match_patch::patch_splitMax(QList<Patch> &patches) {
         patch.length1 = patch.length2 = precontext.length();
         patch.diffs.append(Diff(Equal, precontext));
       }
-      while (!bigpatch.diffs.isEmpty()
-          && patch.length1 < patch_size - Patch_Margin) {
+      while (!bigpatch.diffs.isEmpty() &&
+             patch.length1 < patch_size - Patch_Margin) {
         diff_type = bigpatch.diffs.front().operation;
         diff_text = bigpatch.diffs.front().text;
         if (diff_type == Insert) {
@@ -1967,9 +1919,9 @@ void diff_match_patch::patch_splitMax(QList<Patch> &patches) {
           patch.diffs.append(bigpatch.diffs.front());
           bigpatch.diffs.removeFirst();
           empty = false;
-        } else if (diff_type == Delete && patch.diffs.size() == 1
-            && patch.diffs.front().operation == Equal
-            && diff_text.length() > 2 * patch_size) {
+        } else if (diff_type == Delete && patch.diffs.size() == 1 &&
+                   patch.diffs.front().operation == Equal &&
+                   diff_text.length() > 2 * patch_size) {
           // This is a large deletion.  Let it pass in one chunk.
           patch.length1 += diff_text.length();
           start1 += diff_text.length();
@@ -1978,8 +1930,8 @@ void diff_match_patch::patch_splitMax(QList<Patch> &patches) {
           bigpatch.diffs.removeFirst();
         } else {
           // Deletion or equality.  Only take as much as we can stomach.
-          diff_text = diff_text.left(std::min(diff_text.length(),
-              patch_size - patch.length1 - Patch_Margin));
+          diff_text = diff_text.left(std::min(
+              diff_text.length(), patch_size - patch.length1 - Patch_Margin));
           patch.length1 += diff_text.length();
           start1 += diff_text.length();
           if (diff_type == Equal) {
@@ -1992,8 +1944,8 @@ void diff_match_patch::patch_splitMax(QList<Patch> &patches) {
           if (diff_text == bigpatch.diffs.front().text) {
             bigpatch.diffs.removeFirst();
           } else {
-            bigpatch.diffs.front().text = safeMid(bigpatch.diffs.front().text,
-                diff_text.length());
+            bigpatch.diffs.front().text =
+                safeMid(bigpatch.diffs.front().text, diff_text.length());
           }
         }
       }
@@ -2009,8 +1961,7 @@ void diff_match_patch::patch_splitMax(QList<Patch> &patches) {
       if (!postcontext.isEmpty()) {
         patch.length1 += postcontext.length();
         patch.length2 += postcontext.length();
-        if (!patch.diffs.isEmpty()
-            && patch.diffs.back().operation == Equal) {
+        if (!patch.diffs.isEmpty() && patch.diffs.back().operation == Equal) {
           patch.diffs.back().text += postcontext;
         } else {
           patch.diffs.append(Diff(Equal, postcontext));
@@ -2024,15 +1975,13 @@ void diff_match_patch::patch_splitMax(QList<Patch> &patches) {
   }
 }
 
-
 QString diff_match_patch::patch_toText(const QList<Patch> &patches) {
   QString text;
-  foreach(Patch aPatch, patches) {
+  foreach (Patch aPatch, patches) {
     text.append(aPatch.toString());
   }
   return text;
 }
-
 
 QList<Patch> diff_match_patch::patch_fromText(const QString &textline) {
   QList<Patch> patches;
@@ -2103,7 +2052,6 @@ QList<Patch> diff_match_patch::patch_fromText(const QString &textline) {
     }
 
     patches.append(patch);
-
   }
   return patches;
 }

--- a/cpp/diff_match_patch.cpp
+++ b/cpp/diff_match_patch.cpp
@@ -928,8 +928,8 @@ int diff_match_patch::diff_cleanupSemanticScore(const QString &one,
   bool whitespace2 = nonAlphaNumeric2 && char2.isSpace();
   bool lineBreak1 = whitespace1 && char1.category() == QChar::Other_Control;
   bool lineBreak2 = whitespace2 && char2.category() == QChar::Other_Control;
-  bool blankLine1 = lineBreak1 && BLANKLINEEND.indexIn(one) != -1;
-  bool blankLine2 = lineBreak2 && BLANKLINESTART.indexIn(two) != -1;
+  bool blankLine1 = lineBreak1 && BLANKLINEEND.match(one).hasMatch();
+  bool blankLine2 = lineBreak2 && BLANKLINESTART.match(two).hasMatch();
 
   if (blankLine1 || blankLine2) {
     // Five points for blank lines.
@@ -951,8 +951,8 @@ int diff_match_patch::diff_cleanupSemanticScore(const QString &one,
 }
 
 // Define some regex patterns for matching boundaries.
-QRegExp diff_match_patch::BLANKLINEEND = QRegExp("\\n\\r?\\n$");
-QRegExp diff_match_patch::BLANKLINESTART = QRegExp("^\\r?\\n\\r?\\n");
+QRegularExpression diff_match_patch::BLANKLINEEND = QRegularExpression("\\n\\r?\\n$");
+QRegularExpression diff_match_patch::BLANKLINESTART = QRegularExpression("^\\r?\\n\\r?\\n");
 
 void diff_match_patch::diff_cleanupEfficiency(QList<Diff> &diffs) {
   if (diffs.isEmpty()) {
@@ -1990,35 +1990,36 @@ QList<Patch> diff_match_patch::patch_fromText(const QString &textline) {
   }
   QStringList text = textline.split("\n", QString::SkipEmptyParts);
   Patch patch;
-  QRegExp patchHeader("^@@ -(\\d+),?(\\d*) \\+(\\d+),?(\\d*) @@$");
+  QRegularExpression patchHeader("^@@ -(\\d+),?(\\d*) \\+(\\d+),?(\\d*) @@$");
   char sign;
   QString line;
   while (!text.isEmpty()) {
-    if (!patchHeader.exactMatch(text.front())) {
+    QRegularExpressionMatch match = patchHeader.match(text.front());
+    if (!match.hasMatch()) {
       throw QString("Invalid patch string: %1").arg(text.front());
     }
 
     patch = Patch();
-    patch.start1 = patchHeader.cap(1).toInt();
-    if (patchHeader.cap(2).isEmpty()) {
+    patch.start1 = match.captured(1).toInt();
+    if (match.captured(2).isEmpty()) {
       patch.start1--;
       patch.length1 = 1;
-    } else if (patchHeader.cap(2) == "0") {
+    } else if (match.captured(2) == "0") {
       patch.length1 = 0;
     } else {
       patch.start1--;
-      patch.length1 = patchHeader.cap(2).toInt();
+      patch.length1 = match.captured(2).toInt();
     }
 
-    patch.start2 = patchHeader.cap(3).toInt();
-    if (patchHeader.cap(4).isEmpty()) {
+    patch.start2 = match.captured(3).toInt();
+    if (match.captured(4).isEmpty()) {
       patch.start2--;
       patch.length2 = 1;
-    } else if (patchHeader.cap(4) == "0") {
+    } else if (match.captured(4) == "0") {
       patch.length2 = 0;
     } else {
       patch.start2--;
-      patch.length2 = patchHeader.cap(4).toInt();
+      patch.length2 = match.captured(4).toInt();
     }
     text.removeFirst();
 

--- a/cpp/diff_match_patch.cpp
+++ b/cpp/diff_match_patch.cpp
@@ -553,7 +553,7 @@ void diff_match_patch::diff_charsToLines(QList<Diff> &diffs,
 int diff_match_patch::diff_commonPrefix(const QString &text1,
                                         const QString &text2) {
   // Performance analysis: http://neil.fraser.name/news/2007/10/09/
-  const int n = std::min(text1.length(), text2.length());
+  const int n = std::min<int>(text1.length(), text2.length());
   for (int i = 0; i < n; i++) {
     if (text1[i] != text2[i]) {
       return i;
@@ -567,7 +567,7 @@ int diff_match_patch::diff_commonSuffix(const QString &text1,
   // Performance analysis: http://neil.fraser.name/news/2007/10/09/
   const int text1_length = text1.length();
   const int text2_length = text2.length();
-  const int n = std::min(text1_length, text2_length);
+  const int n = std::min<int>(text1_length, text2_length);
   for (int i = 1; i <= n; i++) {
     if (text1[text1_length - i] != text2[text2_length - i]) {
       return i - 1;
@@ -593,7 +593,7 @@ int diff_match_patch::diff_commonOverlap(const QString &text1,
   } else if (text1_length < text2_length) {
     text2_trunc = text2.left(text1_length);
   }
-  const int text_length = std::min(text1_length, text2_length);
+  const int text_length = std::min<int>(text1_length, text2_length);
   // Quick check for the worst case.
   if (text1_trunc == text2_trunc) {
     return text_length;
@@ -951,8 +951,10 @@ int diff_match_patch::diff_cleanupSemanticScore(const QString &one,
 }
 
 // Define some regex patterns for matching boundaries.
-QRegularExpression diff_match_patch::BLANKLINEEND = QRegularExpression("\\n\\r?\\n$");
-QRegularExpression diff_match_patch::BLANKLINESTART = QRegularExpression("^\\r?\\n\\r?\\n");
+QRegularExpression diff_match_patch::BLANKLINEEND =
+    QRegularExpression("\\n\\r?\\n$");
+QRegularExpression diff_match_patch::BLANKLINESTART =
+    QRegularExpression("^\\r?\\n\\r?\\n");
 
 void diff_match_patch::diff_cleanupEfficiency(QList<Diff> &diffs) {
   if (diffs.isEmpty()) {
@@ -1394,7 +1396,7 @@ int diff_match_patch::match_main(const QString &text, const QString &pattern,
     throw "Null inputs. (match_main)";
   }
 
-  loc = std::max(0, std::min(loc, text.length()));
+  loc = std::max(0, std::min<int>(loc, text.length()));
   if (text == pattern) {
     // Shortcut (potentially not guaranteed by the algorithm)
     return 0;
@@ -1425,13 +1427,13 @@ int diff_match_patch::match_bitap(const QString &text, const QString &pattern,
   // Is there a nearby exact match? (speedup)
   int best_loc = text.indexOf(pattern, loc);
   if (best_loc != -1) {
-    score_threshold =
-        std::min(match_bitapScore(0, best_loc, loc, pattern), score_threshold);
+    score_threshold = std::min<double>(
+        match_bitapScore(0, best_loc, loc, pattern), score_threshold);
     // What about in the other direction? (speedup)
     best_loc = text.lastIndexOf(pattern, loc + pattern.length());
     if (best_loc != -1) {
-      score_threshold = std::min(match_bitapScore(0, best_loc, loc, pattern),
-                                 score_threshold);
+      score_threshold = std::min<double>(
+          match_bitapScore(0, best_loc, loc, pattern), score_threshold);
     }
   }
 
@@ -1459,8 +1461,9 @@ int diff_match_patch::match_bitap(const QString &text, const QString &pattern,
     }
     // Use the result from this iteration as the maximum for the next.
     bin_max = bin_mid;
-    int start = std::max(1, loc - bin_mid + 1);
-    int finish = std::min(loc + bin_mid, text.length()) + pattern.length();
+    int start = std::max<int>(1, loc - bin_mid + 1);
+    int finish =
+        std::min<double>(loc + bin_mid, text.length()) + pattern.length();
 
     rd = new int[finish + 2];
     rd[finish + 1] = (1 << d) - 1;
@@ -1551,7 +1554,7 @@ void diff_match_patch::patch_addContext(Patch &patch, const QString &text) {
     padding += Patch_Margin;
     pattern = safeMid(
         text, std::max(0, patch.start2 - padding),
-        std::min(text.length(), patch.start2 + patch.length1 + padding) -
+        std::min<int>(text.length(), patch.start2 + patch.length1 + padding) -
             std::max(0, patch.start2 - padding));
   }
   // Add one chunk for good luck.
@@ -1564,10 +1567,10 @@ void diff_match_patch::patch_addContext(Patch &patch, const QString &text) {
     patch.diffs.prepend(Diff(Equal, prefix));
   }
   // Add the suffix.
-  QString suffix =
-      safeMid(text, patch.start2 + patch.length1,
-              std::min(text.length(), patch.start2 + patch.length1 + padding) -
-                  (patch.start2 + patch.length1));
+  QString suffix = safeMid(
+      text, patch.start2 + patch.length1,
+      std::min<int>(text.length(), patch.start2 + patch.length1 + padding) -
+          (patch.start2 + patch.length1));
   if (!suffix.isEmpty()) {
     patch.diffs.append(Diff(Equal, suffix));
   }
@@ -1930,7 +1933,7 @@ void diff_match_patch::patch_splitMax(QList<Patch> &patches) {
           bigpatch.diffs.removeFirst();
         } else {
           // Deletion or equality.  Only take as much as we can stomach.
-          diff_text = diff_text.left(std::min(
+          diff_text = diff_text.left(std::min<int>(
               diff_text.length(), patch_size - patch.length1 - Patch_Margin));
           patch.length1 += diff_text.length();
           start1 += diff_text.length();

--- a/cpp/diff_match_patch.cpp
+++ b/cpp/diff_match_patch.cpp
@@ -1048,7 +1048,7 @@ void diff_match_patch::diff_cleanupEfficiency(QList<Diff> &diffs) {
             // There is an equality we can fall back to.
             thisDiff = &equalities.top();
           }
-          while (*thisDiff != pointer.previous()) {
+          while (pointer.hasPrevious() && (*thisDiff != pointer.previous())) {
             // Intentionally empty loop.
           }
           post_ins = post_del = false;

--- a/cpp/diff_match_patch.cpp
+++ b/cpp/diff_match_patch.cpp
@@ -1074,7 +1074,6 @@ void diff_match_patch::diff_cleanupMerge(QList<Diff> &diffs) {
   QString text_insert = "";
   Diff *thisDiff = pointer.hasNext() ? &pointer.next() : nullptr;
   Diff *prevEqual = nullptr;
-  int commonlength;
   while (thisDiff != nullptr) {
     switch (thisDiff->operation) {
       case Insert:
@@ -1102,7 +1101,7 @@ void diff_match_patch::diff_cleanupMerge(QList<Diff> &diffs) {
           }
           if (both_types) {
             // Factor out any common prefixies.
-            commonlength = diff_commonPrefix(text_insert, text_delete);
+            int commonlength = diff_commonPrefix(text_insert, text_delete);
             if (commonlength != 0) {
               if (pointer.hasPrevious()) {
                 thisDiff = &pointer.previous();

--- a/cpp/diff_match_patch.h
+++ b/cpp/diff_match_patch.h
@@ -60,21 +60,17 @@
 
  */
 
-
 /**-
-* The data structure representing a diff is a Linked list of Diff objects:
-* {Diff(Operation.Delete, "Hello"), Diff(Operation.Insert, "Goodbye"),
-*  Diff(Operation.Equal, " world.")}
-* which means: delete "Hello", add "Goodbye" and keep " world."
-*/
-enum Operation {
-  Delete, Insert, Equal
-};
-
+ * The data structure representing a diff is a Linked list of Diff objects:
+ * {Diff(Operation.Delete, "Hello"), Diff(Operation.Insert, "Goodbye"),
+ *  Diff(Operation.Equal, " world.")}
+ * which means: delete "Hello", add "Goodbye" and keep " world."
+ */
+enum Operation { Delete, Insert, Equal };
 
 /**
-* Class representing one diff operation.
-*/
+ * Class representing one diff operation.
+ */
 class Diff {
  public:
   Operation operation;
@@ -97,10 +93,9 @@ class Diff {
   static QString strOperation(Operation op);
 };
 
-
 /**
-* Class representing one patch operation.
-*/
+ * Class representing one patch operation.
+ */
 class Patch {
  public:
   QList<Diff> diffs;
@@ -117,13 +112,11 @@ class Patch {
   QString toString();
 };
 
-
 /**
  * Class containing the diff, match and patch methods.
  * Also contains the behaviour settings.
  */
 class diff_match_patch {
-
   friend class diff_match_patch_test;
 
  public:
@@ -156,13 +149,10 @@ class diff_match_patch {
   static QRegExp BLANKLINEEND;
   static QRegExp BLANKLINESTART;
 
-
  public:
-
   diff_match_patch();
 
   //  DIFF FUNCTIONS
-
 
   /**
    * Find the differences between two texts.
@@ -184,7 +174,8 @@ class diff_match_patch {
    *     If true, then run a faster slightly less optimal diff.
    * @return Linked List of Diff objects.
    */
-  QList<Diff> diff_main(const QString &text1, const QString &text2, bool checklines);
+  QList<Diff> diff_main(const QString &text1, const QString &text2,
+                        bool checklines);
 
   /**
    * Find the differences between two texts.  Simplifies the problem by
@@ -199,7 +190,8 @@ class diff_match_patch {
    * @return Linked List of Diff objects.
    */
  private:
-  QList<Diff> diff_main(const QString &text1, const QString &text2, bool checklines, clock_t deadline);
+  QList<Diff> diff_main(const QString &text1, const QString &text2,
+                        bool checklines, clock_t deadline);
 
   /**
    * Find the differences between two texts.  Assumes that the texts do not
@@ -213,7 +205,8 @@ class diff_match_patch {
    * @return Linked List of Diff objects.
    */
  private:
-  QList<Diff> diff_compute(QString text1, QString text2, bool checklines, clock_t deadline);
+  QList<Diff> diff_compute(QString text1, QString text2, bool checklines,
+                           clock_t deadline);
 
   /**
    * Do a quick line-level diff on both strings, then rediff the parts for
@@ -236,7 +229,8 @@ class diff_match_patch {
    * @return Linked List of Diff objects.
    */
  protected:
-  QList<Diff> diff_bisect(const QString &text1, const QString &text2, clock_t deadline);
+  QList<Diff> diff_bisect(const QString &text1, const QString &text2,
+                          clock_t deadline);
 
   /**
    * Given the location of the 'middle snake', split the diff in two parts
@@ -249,7 +243,8 @@ class diff_match_patch {
    * @return LinkedList of Diff objects.
    */
  private:
-  QList<Diff> diff_bisectSplit(const QString &text1, const QString &text2, int x, int y, clock_t deadline);
+  QList<Diff> diff_bisectSplit(const QString &text1, const QString &text2,
+                               int x, int y, clock_t deadline);
 
   /**
    * Split two texts into a list of strings.  Reduce the texts to a string of
@@ -261,7 +256,10 @@ class diff_match_patch {
    *     of the List of unique strings is intentionally blank.
    */
  protected:
-  QList<QVariant> diff_linesToChars(const QString &text1, const QString &text2); // return elems 0 and 1 are QString, elem 2 is QStringList
+  QList<QVariant> diff_linesToChars(
+      const QString &text1,
+      const QString
+          &text2);  // return elems 0 and 1 are QString, elem 2 is QStringList
 
   /**
    * Split a text into a list of strings.  Reduce the texts to a string of
@@ -336,7 +334,8 @@ class diff_match_patch {
    *     and the common middle.  Or null if there was no match.
    */
  private:
-  QStringList diff_halfMatchI(const QString &longtext, const QString &shorttext, int i);
+  QStringList diff_halfMatchI(const QString &longtext, const QString &shorttext,
+                              int i);
 
   /**
    * Reduce the number of edits by eliminating semantically trivial equalities.
@@ -446,9 +445,7 @@ class diff_match_patch {
  public:
   QList<Diff> diff_fromDelta(const QString &text1, const QString &delta);
 
-
   //  MATCH FUNCTIONS
-
 
   /**
    * Locate the best instance of 'pattern' in 'text' near 'loc'.
@@ -491,9 +488,7 @@ class diff_match_patch {
  protected:
   QMap<QChar, int> match_alphabet(const QString &pattern);
 
-
- //  PATCH FUNCTIONS
-
+  //  PATCH FUNCTIONS
 
   /**
    * Increase the context until it is unique,
@@ -530,10 +525,12 @@ class diff_match_patch {
    * @param text2 Ignored.
    * @param diffs Array of diff tuples for text1 to text2.
    * @return LinkedList of Patch objects.
-   * @deprecated Prefer patch_make(const QString &text1, const QList<Diff> &diffs).
+   * @deprecated Prefer patch_make(const QString &text1, const QList<Diff>
+   * &diffs).
    */
  public:
-  QList<Patch> patch_make(const QString &text1, const QString &text2, const QList<Diff> &diffs);
+  QList<Patch> patch_make(const QString &text1, const QString &text2,
+                          const QList<Diff> &diffs);
 
   /**
    * Compute a list of patches to turn text1 into text2.
@@ -562,7 +559,8 @@ class diff_match_patch {
    *      boolean values.
    */
  public:
-  QPair<QString,QVector<bool> > patch_apply(QList<Patch> &patches, const QString &text);
+  QPair<QString, QVector<bool> > patch_apply(QList<Patch> &patches,
+                                             const QString &text);
 
   /**
    * Add some padding on text start and end so that edges can match something.
@@ -626,4 +624,4 @@ class diff_match_patch {
   }
 };
 
-#endif // DIFF_MATCH_PATCH_H
+#endif  // DIFF_MATCH_PATCH_H

--- a/cpp/diff_match_patch.h
+++ b/cpp/diff_match_patch.h
@@ -146,8 +146,8 @@ class diff_match_patch {
 
  private:
   // Define some regex patterns for matching boundaries.
-  static QRegExp BLANKLINEEND;
-  static QRegExp BLANKLINESTART;
+  static QRegularExpression BLANKLINEEND;
+  static QRegularExpression BLANKLINESTART;
 
  public:
   diff_match_patch();

--- a/cpp/diff_match_patch_test.cpp
+++ b/cpp/diff_match_patch_test.cpp
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
 diff_match_patch_test::diff_match_patch_test() {}
 
 int diff_match_patch_test::run_all_tests() {
-  QTime t;
+  QElapsedTimer t;
   int result = 0;
   t.start();
   try {
@@ -78,7 +78,7 @@ int diff_match_patch_test::run_all_tests() {
     qDebug("Test failed: %s", qPrintable(strCase));
     result = -1;
   }
-  qDebug("Total time: %d ms", t.elapsed());
+  qDebug("Total time: %lld ms", t.elapsed());
   return result;
 }
 

--- a/cpp/diff_match_patch_test.cpp
+++ b/cpp/diff_match_patch_test.cpp
@@ -22,6 +22,7 @@
 
 // Code known to compile and run with Qt 4.3 through Qt 4.7.
 #include <QtCore>
+
 #include "diff_match_patch.h"
 #include "diff_match_patch_test.h"
 
@@ -35,9 +36,7 @@ int main(int argc, char **argv) {
   Q_UNUSED(argv)
 }
 
-
-diff_match_patch_test::diff_match_patch_test() {
-}
+diff_match_patch_test::diff_match_patch_test() {}
 
 int diff_match_patch_test::run_all_tests() {
   QTime t;
@@ -87,63 +86,99 @@ int diff_match_patch_test::run_all_tests() {
 
 void diff_match_patch_test::testDiffCommonPrefix() {
   // Detect any common prefix.
-  assertEquals("diff_commonPrefix: Null case.", 0, dmp.diff_commonPrefix("abc", "xyz"));
+  assertEquals("diff_commonPrefix: Null case.", 0,
+               dmp.diff_commonPrefix("abc", "xyz"));
 
-  assertEquals("diff_commonPrefix: Non-null case.", 4, dmp.diff_commonPrefix("1234abcdef", "1234xyz"));
+  assertEquals("diff_commonPrefix: Non-null case.", 4,
+               dmp.diff_commonPrefix("1234abcdef", "1234xyz"));
 
-  assertEquals("diff_commonPrefix: Whole case.", 4, dmp.diff_commonPrefix("1234", "1234xyz"));
+  assertEquals("diff_commonPrefix: Whole case.", 4,
+               dmp.diff_commonPrefix("1234", "1234xyz"));
 }
 
 void diff_match_patch_test::testDiffCommonSuffix() {
   // Detect any common suffix.
-  assertEquals("diff_commonSuffix: Null case.", 0, dmp.diff_commonSuffix("abc", "xyz"));
+  assertEquals("diff_commonSuffix: Null case.", 0,
+               dmp.diff_commonSuffix("abc", "xyz"));
 
-  assertEquals("diff_commonSuffix: Non-null case.", 4, dmp.diff_commonSuffix("abcdef1234", "xyz1234"));
+  assertEquals("diff_commonSuffix: Non-null case.", 4,
+               dmp.diff_commonSuffix("abcdef1234", "xyz1234"));
 
-  assertEquals("diff_commonSuffix: Whole case.", 4, dmp.diff_commonSuffix("1234", "xyz1234"));
+  assertEquals("diff_commonSuffix: Whole case.", 4,
+               dmp.diff_commonSuffix("1234", "xyz1234"));
 }
 
 void diff_match_patch_test::testDiffCommonOverlap() {
   // Detect any suffix/prefix overlap.
-  assertEquals("diff_commonOverlap: Null case.", 0, dmp.diff_commonOverlap("", "abcd"));
+  assertEquals("diff_commonOverlap: Null case.", 0,
+               dmp.diff_commonOverlap("", "abcd"));
 
-  assertEquals("diff_commonOverlap: Whole case.", 3, dmp.diff_commonOverlap("abc", "abcd"));
+  assertEquals("diff_commonOverlap: Whole case.", 3,
+               dmp.diff_commonOverlap("abc", "abcd"));
 
-  assertEquals("diff_commonOverlap: No overlap.", 0, dmp.diff_commonOverlap("123456", "abcd"));
+  assertEquals("diff_commonOverlap: No overlap.", 0,
+               dmp.diff_commonOverlap("123456", "abcd"));
 
-  assertEquals("diff_commonOverlap: Overlap.", 3, dmp.diff_commonOverlap("123456xxx", "xxxabcd"));
+  assertEquals("diff_commonOverlap: Overlap.", 3,
+               dmp.diff_commonOverlap("123456xxx", "xxxabcd"));
 
   // Some overly clever languages (C#) may treat ligatures as equal to their
   // component letters.  E.g. U+FB01 == 'fi'
-  assertEquals("diff_commonOverlap: Unicode.", 0, dmp.diff_commonOverlap("fi", QString::fromWCharArray((const wchar_t*) L"\ufb01i", 2)));
+  assertEquals(
+      "diff_commonOverlap: Unicode.", 0,
+      dmp.diff_commonOverlap(
+          "fi", QString::fromWCharArray((const wchar_t *)L"\ufb01i", 2)));
 }
 
 void diff_match_patch_test::testDiffHalfmatch() {
   // Detect a halfmatch.
   dmp.Diff_Timeout = 1;
-  assertEmpty("diff_halfMatch: No match #1.", dmp.diff_halfMatch("1234567890", "abcdef"));
+  assertEmpty("diff_halfMatch: No match #1.",
+              dmp.diff_halfMatch("1234567890", "abcdef"));
 
-  assertEmpty("diff_halfMatch: No match #2.", dmp.diff_halfMatch("12345", "23"));
+  assertEmpty("diff_halfMatch: No match #2.",
+              dmp.diff_halfMatch("12345", "23"));
 
-  assertEquals("diff_halfMatch: Single Match #1.", QString("12,90,a,z,345678").split(","), dmp.diff_halfMatch("1234567890", "a345678z"));
+  assertEquals("diff_halfMatch: Single Match #1.",
+               QString("12,90,a,z,345678").split(","),
+               dmp.diff_halfMatch("1234567890", "a345678z"));
 
-  assertEquals("diff_halfMatch: Single Match #2.", QString("a,z,12,90,345678").split(","), dmp.diff_halfMatch("a345678z", "1234567890"));
+  assertEquals("diff_halfMatch: Single Match #2.",
+               QString("a,z,12,90,345678").split(","),
+               dmp.diff_halfMatch("a345678z", "1234567890"));
 
-  assertEquals("diff_halfMatch: Single Match #3.", QString("abc,z,1234,0,56789").split(","), dmp.diff_halfMatch("abc56789z", "1234567890"));
+  assertEquals("diff_halfMatch: Single Match #3.",
+               QString("abc,z,1234,0,56789").split(","),
+               dmp.diff_halfMatch("abc56789z", "1234567890"));
 
-  assertEquals("diff_halfMatch: Single Match #4.", QString("a,xyz,1,7890,23456").split(","), dmp.diff_halfMatch("a23456xyz", "1234567890"));
+  assertEquals("diff_halfMatch: Single Match #4.",
+               QString("a,xyz,1,7890,23456").split(","),
+               dmp.diff_halfMatch("a23456xyz", "1234567890"));
 
-  assertEquals("diff_halfMatch: Multiple Matches #1.", QString("12123,123121,a,z,1234123451234").split(","), dmp.diff_halfMatch("121231234123451234123121", "a1234123451234z"));
+  assertEquals(
+      "diff_halfMatch: Multiple Matches #1.",
+      QString("12123,123121,a,z,1234123451234").split(","),
+      dmp.diff_halfMatch("121231234123451234123121", "a1234123451234z"));
 
-  assertEquals("diff_halfMatch: Multiple Matches #2.", QString(",-=-=-=-=-=,x,,x-=-=-=-=-=-=-=").split(","), dmp.diff_halfMatch("x-=-=-=-=-=-=-=-=-=-=-=-=", "xx-=-=-=-=-=-=-="));
+  assertEquals(
+      "diff_halfMatch: Multiple Matches #2.",
+      QString(",-=-=-=-=-=,x,,x-=-=-=-=-=-=-=").split(","),
+      dmp.diff_halfMatch("x-=-=-=-=-=-=-=-=-=-=-=-=", "xx-=-=-=-=-=-=-="));
 
-  assertEquals("diff_halfMatch: Multiple Matches #3.", QString("-=-=-=-=-=,,,y,-=-=-=-=-=-=-=y").split(","), dmp.diff_halfMatch("-=-=-=-=-=-=-=-=-=-=-=-=y", "-=-=-=-=-=-=-=yy"));
+  assertEquals(
+      "diff_halfMatch: Multiple Matches #3.",
+      QString("-=-=-=-=-=,,,y,-=-=-=-=-=-=-=y").split(","),
+      dmp.diff_halfMatch("-=-=-=-=-=-=-=-=-=-=-=-=y", "-=-=-=-=-=-=-=yy"));
 
-  // Optimal diff would be -q+x=H-i+e=lloHe+Hu=llo-Hew+y not -qHillo+x=HelloHe-w+Hulloy
-  assertEquals("diff_halfMatch: Non-optimal halfmatch.", QString("qHillo,w,x,Hulloy,HelloHe").split(","), dmp.diff_halfMatch("qHilloHelloHew", "xHelloHeHulloy"));
+  // Optimal diff would be -q+x=H-i+e=lloHe+Hu=llo-Hew+y not
+  // -qHillo+x=HelloHe-w+Hulloy
+  assertEquals("diff_halfMatch: Non-optimal halfmatch.",
+               QString("qHillo,w,x,Hulloy,HelloHe").split(","),
+               dmp.diff_halfMatch("qHilloHelloHew", "xHelloHeHulloy"));
 
   dmp.Diff_Timeout = 0;
-  assertEmpty("diff_halfMatch: Optimal no halfmatch.", dmp.diff_halfMatch("qHilloHelloHew", "xHelloHeHulloy"));
+  assertEmpty("diff_halfMatch: Optimal no halfmatch.",
+              dmp.diff_halfMatch("qHilloHelloHew", "xHelloHeHulloy"));
 }
 
 void diff_match_patch_test::testDiffLinesToChars() {
@@ -153,10 +188,16 @@ void diff_match_patch_test::testDiffLinesToChars() {
   tmpVector.append("");
   tmpVector.append("alpha\n");
   tmpVector.append("beta\n");
-  tmpVarList << QVariant::fromValue(QString() + QChar((ushort)1) + QChar((ushort)2) + QChar((ushort)1));  //(("\u0001\u0002\u0001"));
-  tmpVarList << QVariant::fromValue(QString() + QChar((ushort)2) + QChar((ushort)1) + QChar((ushort)2));  // (("\u0002\u0001\u0002"));
+  tmpVarList << QVariant::fromValue(
+      QString() + QChar((ushort)1) + QChar((ushort)2) +
+      QChar((ushort)1));  //(("\u0001\u0002\u0001"));
+  tmpVarList << QVariant::fromValue(
+      QString() + QChar((ushort)2) + QChar((ushort)1) +
+      QChar((ushort)2));  // (("\u0002\u0001\u0002"));
   tmpVarList << QVariant::fromValue(tmpVector);
-  assertEquals("diff_linesToChars:", tmpVarList, dmp.diff_linesToChars("alpha\nbeta\nalpha\n", "beta\nalpha\nbeta\n"));
+  assertEquals(
+      "diff_linesToChars:", tmpVarList,
+      dmp.diff_linesToChars("alpha\nbeta\nalpha\n", "beta\nalpha\nbeta\n"));
 
   tmpVector.clear();
   tmpVarList.clear();
@@ -165,19 +206,25 @@ void diff_match_patch_test::testDiffLinesToChars() {
   tmpVector.append("beta\r\n");
   tmpVector.append("\r\n");
   tmpVarList << QVariant::fromValue(QString(""));
-  tmpVarList << QVariant::fromValue(QString() + QChar((ushort)1) + QChar((ushort)2) + QChar((ushort)3) + QChar((ushort)3));  // (("\u0001\u0002\u0003\u0003"));
+  tmpVarList << QVariant::fromValue(
+      QString() + QChar((ushort)1) + QChar((ushort)2) + QChar((ushort)3) +
+      QChar((ushort)3));  // (("\u0001\u0002\u0003\u0003"));
   tmpVarList << QVariant::fromValue(tmpVector);
-  assertEquals("diff_linesToChars:", tmpVarList, dmp.diff_linesToChars("", "alpha\r\nbeta\r\n\r\n\r\n"));
+  assertEquals("diff_linesToChars:", tmpVarList,
+               dmp.diff_linesToChars("", "alpha\r\nbeta\r\n\r\n\r\n"));
 
   tmpVector.clear();
   tmpVarList.clear();
   tmpVector.append("");
   tmpVector.append("a");
   tmpVector.append("b");
-  tmpVarList << QVariant::fromValue(QString() + QChar((ushort)1));  // (("\u0001"));
-  tmpVarList << QVariant::fromValue(QString() + QChar((ushort)2));  // (("\u0002"));
+  tmpVarList << QVariant::fromValue(QString() +
+                                    QChar((ushort)1));  // (("\u0001"));
+  tmpVarList << QVariant::fromValue(QString() +
+                                    QChar((ushort)2));  // (("\u0002"));
   tmpVarList << QVariant::fromValue(tmpVector);
-  assertEquals("diff_linesToChars:", tmpVarList, dmp.diff_linesToChars("a", "b"));
+  assertEquals("diff_linesToChars:", tmpVarList,
+               dmp.diff_linesToChars("a", "b"));
 
   // More than 256 to reveal any 8-bit limitations.
   int n = 300;
@@ -190,13 +237,15 @@ void diff_match_patch_test::testDiffLinesToChars() {
     lines += QString::number(x) + "\n";
     chars += QChar(static_cast<ushort>(x));
   }
-  assertEquals("diff_linesToChars: More than 256 (setup).", n, tmpVector.size());
+  assertEquals("diff_linesToChars: More than 256 (setup).", n,
+               tmpVector.size());
   assertEquals("diff_linesToChars: More than 256 (setup).", n, chars.length());
   tmpVector.prepend("");
   tmpVarList << QVariant::fromValue(chars);
   tmpVarList << QVariant::fromValue(QString(""));
   tmpVarList << QVariant::fromValue(tmpVector);
-  assertEquals("diff_linesToChars: More than 256.", tmpVarList, dmp.diff_linesToChars(lines, ""));
+  assertEquals("diff_linesToChars: More than 256.", tmpVarList,
+               dmp.diff_linesToChars(lines, ""));
 }
 
 void diff_match_patch_test::testDiffCharsToLines() {
@@ -207,14 +256,19 @@ void diff_match_patch_test::testDiffCharsToLines() {
 
   // Convert chars up to lines.
   QList<Diff> diffs;
-  diffs << Diff(Equal, QString() + QChar((ushort)1) + QChar((ushort)2) + QChar((ushort)1));  // ("\u0001\u0002\u0001");
-  diffs << Diff(Insert, QString() + QChar((ushort)2) + QChar((ushort)1) + QChar((ushort)2));  // ("\u0002\u0001\u0002");
+  diffs << Diff(Equal, QString() + QChar((ushort)1) + QChar((ushort)2) +
+                           QChar((ushort)1));  // ("\u0001\u0002\u0001");
+  diffs << Diff(Insert, QString() + QChar((ushort)2) + QChar((ushort)1) +
+                            QChar((ushort)2));  // ("\u0002\u0001\u0002");
   QStringList tmpVector;
   tmpVector.append("");
   tmpVector.append("alpha\n");
   tmpVector.append("beta\n");
   dmp.diff_charsToLines(diffs, tmpVector);
-  assertEquals("diff_charsToLines:", diffList(Diff(Equal, "alpha\nbeta\nalpha\n"), Diff(Insert, "beta\nalpha\nbeta\n")), diffs);
+  assertEquals("diff_charsToLines:",
+               diffList(Diff(Equal, "alpha\nbeta\nalpha\n"),
+                        Diff(Insert, "beta\nalpha\nbeta\n")),
+               diffs);
 
   // More than 256 to reveal any 8-bit limitations.
   int n = 300;
@@ -227,12 +281,14 @@ void diff_match_patch_test::testDiffCharsToLines() {
     lines += QString::number(x) + "\n";
     chars += QChar(static_cast<ushort>(x));
   }
-  assertEquals("diff_linesToChars: More than 256 (setup).", n, tmpVector.size());
+  assertEquals("diff_linesToChars: More than 256 (setup).", n,
+               tmpVector.size());
   assertEquals("diff_linesToChars: More than 256 (setup).", n, chars.length());
   tmpVector.prepend("");
   diffs = diffList(Diff(Delete, chars));
   dmp.diff_charsToLines(diffs, tmpVector);
-  assertEquals("diff_charsToLines: More than 256.", diffList(Diff(Delete, lines)), diffs);
+  assertEquals("diff_charsToLines: More than 256.",
+               diffList(Diff(Delete, lines)), diffs);
 }
 
 void diff_match_patch_test::testDiffCleanupMerge() {
@@ -243,47 +299,70 @@ void diff_match_patch_test::testDiffCleanupMerge() {
 
   diffs = diffList(Diff(Equal, "a"), Diff(Delete, "b"), Diff(Insert, "c"));
   dmp.diff_cleanupMerge(diffs);
-  assertEquals("diff_cleanupMerge: No change case.", diffList(Diff(Equal, "a"), Diff(Delete, "b"), Diff(Insert, "c")), diffs);
+  assertEquals("diff_cleanupMerge: No change case.",
+               diffList(Diff(Equal, "a"), Diff(Delete, "b"), Diff(Insert, "c")),
+               diffs);
 
   diffs = diffList(Diff(Equal, "a"), Diff(Equal, "b"), Diff(Equal, "c"));
   dmp.diff_cleanupMerge(diffs);
-  assertEquals("diff_cleanupMerge: Merge equalities.", diffList(Diff(Equal, "abc")), diffs);
+  assertEquals("diff_cleanupMerge: Merge equalities.",
+               diffList(Diff(Equal, "abc")), diffs);
 
   diffs = diffList(Diff(Delete, "a"), Diff(Delete, "b"), Diff(Delete, "c"));
   dmp.diff_cleanupMerge(diffs);
-  assertEquals("diff_cleanupMerge: Merge deletions.", diffList(Diff(Delete, "abc")), diffs);
+  assertEquals("diff_cleanupMerge: Merge deletions.",
+               diffList(Diff(Delete, "abc")), diffs);
 
   diffs = diffList(Diff(Insert, "a"), Diff(Insert, "b"), Diff(Insert, "c"));
   dmp.diff_cleanupMerge(diffs);
-  assertEquals("diff_cleanupMerge: Merge insertions.", diffList(Diff(Insert, "abc")), diffs);
+  assertEquals("diff_cleanupMerge: Merge insertions.",
+               diffList(Diff(Insert, "abc")), diffs);
 
-  diffs = diffList(Diff(Delete, "a"), Diff(Insert, "b"), Diff(Delete, "c"), Diff(Insert, "d"), Diff(Equal, "e"), Diff(Equal, "f"));
+  diffs = diffList(Diff(Delete, "a"), Diff(Insert, "b"), Diff(Delete, "c"),
+                   Diff(Insert, "d"), Diff(Equal, "e"), Diff(Equal, "f"));
   dmp.diff_cleanupMerge(diffs);
-  assertEquals("diff_cleanupMerge: Merge interweave.", diffList(Diff(Delete, "ac"), Diff(Insert, "bd"), Diff(Equal, "ef")), diffs);
+  assertEquals(
+      "diff_cleanupMerge: Merge interweave.",
+      diffList(Diff(Delete, "ac"), Diff(Insert, "bd"), Diff(Equal, "ef")),
+      diffs);
 
   diffs = diffList(Diff(Delete, "a"), Diff(Insert, "abc"), Diff(Delete, "dc"));
   dmp.diff_cleanupMerge(diffs);
-  assertEquals("diff_cleanupMerge: Prefix and suffix detection.", diffList(Diff(Equal, "a"), Diff(Delete, "d"), Diff(Insert, "b"), Diff(Equal, "c")), diffs);
+  assertEquals("diff_cleanupMerge: Prefix and suffix detection.",
+               diffList(Diff(Equal, "a"), Diff(Delete, "d"), Diff(Insert, "b"),
+                        Diff(Equal, "c")),
+               diffs);
 
-  diffs = diffList(Diff(Equal, "x"), Diff(Delete, "a"), Diff(Insert, "abc"), Diff(Delete, "dc"), Diff(Equal, "y"));
+  diffs = diffList(Diff(Equal, "x"), Diff(Delete, "a"), Diff(Insert, "abc"),
+                   Diff(Delete, "dc"), Diff(Equal, "y"));
   dmp.diff_cleanupMerge(diffs);
-  assertEquals("diff_cleanupMerge: Prefix and suffix detection with equalities.", diffList(Diff(Equal, "xa"), Diff(Delete, "d"), Diff(Insert, "b"), Diff(Equal, "cy")), diffs);
+  assertEquals(
+      "diff_cleanupMerge: Prefix and suffix detection with equalities.",
+      diffList(Diff(Equal, "xa"), Diff(Delete, "d"), Diff(Insert, "b"),
+               Diff(Equal, "cy")),
+      diffs);
 
   diffs = diffList(Diff(Equal, "a"), Diff(Insert, "ba"), Diff(Equal, "c"));
   dmp.diff_cleanupMerge(diffs);
-  assertEquals("diff_cleanupMerge: Slide edit left.", diffList(Diff(Insert, "ab"), Diff(Equal, "ac")), diffs);
+  assertEquals("diff_cleanupMerge: Slide edit left.",
+               diffList(Diff(Insert, "ab"), Diff(Equal, "ac")), diffs);
 
   diffs = diffList(Diff(Equal, "c"), Diff(Insert, "ab"), Diff(Equal, "a"));
   dmp.diff_cleanupMerge(diffs);
-  assertEquals("diff_cleanupMerge: Slide edit right.", diffList(Diff(Equal, "ca"), Diff(Insert, "ba")), diffs);
+  assertEquals("diff_cleanupMerge: Slide edit right.",
+               diffList(Diff(Equal, "ca"), Diff(Insert, "ba")), diffs);
 
-  diffs = diffList(Diff(Equal, "a"), Diff(Delete, "b"), Diff(Equal, "c"), Diff(Delete, "ac"), Diff(Equal, "x"));
+  diffs = diffList(Diff(Equal, "a"), Diff(Delete, "b"), Diff(Equal, "c"),
+                   Diff(Delete, "ac"), Diff(Equal, "x"));
   dmp.diff_cleanupMerge(diffs);
-  assertEquals("diff_cleanupMerge: Slide edit left recursive.", diffList(Diff(Delete, "abc"), Diff(Equal, "acx")), diffs);
+  assertEquals("diff_cleanupMerge: Slide edit left recursive.",
+               diffList(Diff(Delete, "abc"), Diff(Equal, "acx")), diffs);
 
-  diffs = diffList(Diff(Equal, "x"), Diff(Delete, "ca"), Diff(Equal, "c"), Diff(Delete, "b"), Diff(Equal, "a"));
+  diffs = diffList(Diff(Equal, "x"), Diff(Delete, "ca"), Diff(Equal, "c"),
+                   Diff(Delete, "b"), Diff(Equal, "a"));
   dmp.diff_cleanupMerge(diffs);
-  assertEquals("diff_cleanupMerge: Slide edit right recursive.", diffList(Diff(Equal, "xca"), Diff(Delete, "cba")), diffs);
+  assertEquals("diff_cleanupMerge: Slide edit right recursive.",
+               diffList(Diff(Equal, "xca"), Diff(Delete, "cba")), diffs);
 }
 
 void diff_match_patch_test::testDiffCleanupSemanticLossless() {
@@ -292,33 +371,56 @@ void diff_match_patch_test::testDiffCleanupSemanticLossless() {
   dmp.diff_cleanupSemanticLossless(diffs);
   assertEquals("diff_cleanupSemantic: Null case.", diffList(), diffs);
 
-  diffs = diffList(Diff(Equal, "AAA\r\n\r\nBBB"), Diff(Insert, "\r\nDDD\r\n\r\nBBB"), Diff(Equal, "\r\nEEE"));
+  diffs = diffList(Diff(Equal, "AAA\r\n\r\nBBB"),
+                   Diff(Insert, "\r\nDDD\r\n\r\nBBB"), Diff(Equal, "\r\nEEE"));
   dmp.diff_cleanupSemanticLossless(diffs);
-  assertEquals("diff_cleanupSemanticLossless: Blank lines.", diffList(Diff(Equal, "AAA\r\n\r\n"), Diff(Insert, "BBB\r\nDDD\r\n\r\n"), Diff(Equal, "BBB\r\nEEE")), diffs);
+  assertEquals(
+      "diff_cleanupSemanticLossless: Blank lines.",
+      diffList(Diff(Equal, "AAA\r\n\r\n"), Diff(Insert, "BBB\r\nDDD\r\n\r\n"),
+               Diff(Equal, "BBB\r\nEEE")),
+      diffs);
 
-  diffs = diffList(Diff(Equal, "AAA\r\nBBB"), Diff(Insert, " DDD\r\nBBB"), Diff(Equal, " EEE"));
+  diffs = diffList(Diff(Equal, "AAA\r\nBBB"), Diff(Insert, " DDD\r\nBBB"),
+                   Diff(Equal, " EEE"));
   dmp.diff_cleanupSemanticLossless(diffs);
-  assertEquals("diff_cleanupSemanticLossless: Line boundaries.", diffList(Diff(Equal, "AAA\r\n"), Diff(Insert, "BBB DDD\r\n"), Diff(Equal, "BBB EEE")), diffs);
+  assertEquals("diff_cleanupSemanticLossless: Line boundaries.",
+               diffList(Diff(Equal, "AAA\r\n"), Diff(Insert, "BBB DDD\r\n"),
+                        Diff(Equal, "BBB EEE")),
+               diffs);
 
-  diffs = diffList(Diff(Equal, "The c"), Diff(Insert, "ow and the c"), Diff(Equal, "at."));
+  diffs = diffList(Diff(Equal, "The c"), Diff(Insert, "ow and the c"),
+                   Diff(Equal, "at."));
   dmp.diff_cleanupSemanticLossless(diffs);
-  assertEquals("diff_cleanupSemantic: Word boundaries.", diffList(Diff(Equal, "The "), Diff(Insert, "cow and the "), Diff(Equal, "cat.")), diffs);
+  assertEquals("diff_cleanupSemantic: Word boundaries.",
+               diffList(Diff(Equal, "The "), Diff(Insert, "cow and the "),
+                        Diff(Equal, "cat.")),
+               diffs);
 
-  diffs = diffList(Diff(Equal, "The-c"), Diff(Insert, "ow-and-the-c"), Diff(Equal, "at."));
+  diffs = diffList(Diff(Equal, "The-c"), Diff(Insert, "ow-and-the-c"),
+                   Diff(Equal, "at."));
   dmp.diff_cleanupSemanticLossless(diffs);
-  assertEquals("diff_cleanupSemantic: Alphanumeric boundaries.", diffList(Diff(Equal, "The-"), Diff(Insert, "cow-and-the-"), Diff(Equal, "cat.")), diffs);
+  assertEquals("diff_cleanupSemantic: Alphanumeric boundaries.",
+               diffList(Diff(Equal, "The-"), Diff(Insert, "cow-and-the-"),
+                        Diff(Equal, "cat.")),
+               diffs);
 
   diffs = diffList(Diff(Equal, "a"), Diff(Delete, "a"), Diff(Equal, "ax"));
   dmp.diff_cleanupSemanticLossless(diffs);
-  assertEquals("diff_cleanupSemantic: Hitting the start.", diffList(Diff(Delete, "a"), Diff(Equal, "aax")), diffs);
+  assertEquals("diff_cleanupSemantic: Hitting the start.",
+               diffList(Diff(Delete, "a"), Diff(Equal, "aax")), diffs);
 
   diffs = diffList(Diff(Equal, "xa"), Diff(Delete, "a"), Diff(Equal, "a"));
   dmp.diff_cleanupSemanticLossless(diffs);
-  assertEquals("diff_cleanupSemantic: Hitting the end.", diffList(Diff(Equal, "xaa"), Diff(Delete, "a")), diffs);
+  assertEquals("diff_cleanupSemantic: Hitting the end.",
+               diffList(Diff(Equal, "xaa"), Diff(Delete, "a")), diffs);
 
-  diffs = diffList(Diff(Equal, "The xxx. The "), Diff(Insert, "zzz. The "), Diff(Equal, "yyy."));
+  diffs = diffList(Diff(Equal, "The xxx. The "), Diff(Insert, "zzz. The "),
+                   Diff(Equal, "yyy."));
   dmp.diff_cleanupSemanticLossless(diffs);
-  assertEquals("diff_cleanupSemantic: Sentence boundaries.", diffList(Diff(Equal, "The xxx."), Diff(Insert, " The zzz."), Diff(Equal, " The yyy.")), diffs);
+  assertEquals("diff_cleanupSemantic: Sentence boundaries.",
+               diffList(Diff(Equal, "The xxx."), Diff(Insert, " The zzz."),
+                        Diff(Equal, " The yyy.")),
+               diffs);
 }
 
 void diff_match_patch_test::testDiffCleanupSemantic() {
@@ -327,45 +429,77 @@ void diff_match_patch_test::testDiffCleanupSemantic() {
   dmp.diff_cleanupSemantic(diffs);
   assertEquals("diff_cleanupSemantic: Null case.", diffList(), diffs);
 
-  diffs = diffList(Diff(Delete, "ab"), Diff(Insert, "cd"), Diff(Equal, "12"), Diff(Delete, "e"));
+  diffs = diffList(Diff(Delete, "ab"), Diff(Insert, "cd"), Diff(Equal, "12"),
+                   Diff(Delete, "e"));
   dmp.diff_cleanupSemantic(diffs);
-  assertEquals("diff_cleanupSemantic: No elimination #1.", diffList(Diff(Delete, "ab"), Diff(Insert, "cd"), Diff(Equal, "12"), Diff(Delete, "e")), diffs);
+  assertEquals("diff_cleanupSemantic: No elimination #1.",
+               diffList(Diff(Delete, "ab"), Diff(Insert, "cd"),
+                        Diff(Equal, "12"), Diff(Delete, "e")),
+               diffs);
 
-  diffs = diffList(Diff(Delete, "abc"), Diff(Insert, "ABC"), Diff(Equal, "1234"), Diff(Delete, "wxyz"));
+  diffs = diffList(Diff(Delete, "abc"), Diff(Insert, "ABC"),
+                   Diff(Equal, "1234"), Diff(Delete, "wxyz"));
   dmp.diff_cleanupSemantic(diffs);
-  assertEquals("diff_cleanupSemantic: No elimination #2.", diffList(Diff(Delete, "abc"), Diff(Insert, "ABC"), Diff(Equal, "1234"), Diff(Delete, "wxyz")), diffs);
+  assertEquals("diff_cleanupSemantic: No elimination #2.",
+               diffList(Diff(Delete, "abc"), Diff(Insert, "ABC"),
+                        Diff(Equal, "1234"), Diff(Delete, "wxyz")),
+               diffs);
 
   diffs = diffList(Diff(Delete, "a"), Diff(Equal, "b"), Diff(Delete, "c"));
   dmp.diff_cleanupSemantic(diffs);
-  assertEquals("diff_cleanupSemantic: Simple elimination.", diffList(Diff(Delete, "abc"), Diff(Insert, "b")), diffs);
+  assertEquals("diff_cleanupSemantic: Simple elimination.",
+               diffList(Diff(Delete, "abc"), Diff(Insert, "b")), diffs);
 
-  diffs = diffList(Diff(Delete, "ab"), Diff(Equal, "cd"), Diff(Delete, "e"), Diff(Equal, "f"), Diff(Insert, "g"));
+  diffs = diffList(Diff(Delete, "ab"), Diff(Equal, "cd"), Diff(Delete, "e"),
+                   Diff(Equal, "f"), Diff(Insert, "g"));
   dmp.diff_cleanupSemantic(diffs);
-  assertEquals("diff_cleanupSemantic: Backpass elimination.", diffList(Diff(Delete, "abcdef"), Diff(Insert, "cdfg")), diffs);
+  assertEquals("diff_cleanupSemantic: Backpass elimination.",
+               diffList(Diff(Delete, "abcdef"), Diff(Insert, "cdfg")), diffs);
 
-  diffs = diffList(Diff(Insert, "1"), Diff(Equal, "A"), Diff(Delete, "B"), Diff(Insert, "2"), Diff(Equal, "_"), Diff(Insert, "1"), Diff(Equal, "A"), Diff(Delete, "B"), Diff(Insert, "2"));
+  diffs = diffList(Diff(Insert, "1"), Diff(Equal, "A"), Diff(Delete, "B"),
+                   Diff(Insert, "2"), Diff(Equal, "_"), Diff(Insert, "1"),
+                   Diff(Equal, "A"), Diff(Delete, "B"), Diff(Insert, "2"));
   dmp.diff_cleanupSemantic(diffs);
-  assertEquals("diff_cleanupSemantic: Multiple elimination.", diffList(Diff(Delete, "AB_AB"), Diff(Insert, "1A2_1A2")), diffs);
+  assertEquals("diff_cleanupSemantic: Multiple elimination.",
+               diffList(Diff(Delete, "AB_AB"), Diff(Insert, "1A2_1A2")), diffs);
 
-  diffs = diffList(Diff(Equal, "The c"), Diff(Delete, "ow and the c"), Diff(Equal, "at."));
+  diffs = diffList(Diff(Equal, "The c"), Diff(Delete, "ow and the c"),
+                   Diff(Equal, "at."));
   dmp.diff_cleanupSemantic(diffs);
-  assertEquals("diff_cleanupSemantic: Word boundaries.", diffList(Diff(Equal, "The "), Diff(Delete, "cow and the "), Diff(Equal, "cat.")), diffs);
+  assertEquals("diff_cleanupSemantic: Word boundaries.",
+               diffList(Diff(Equal, "The "), Diff(Delete, "cow and the "),
+                        Diff(Equal, "cat.")),
+               diffs);
 
   diffs = diffList(Diff(Delete, "abcxx"), Diff(Insert, "xxdef"));
   dmp.diff_cleanupSemantic(diffs);
-  assertEquals("diff_cleanupSemantic: No overlap elimination.", diffList(Diff(Delete, "abcxx"), Diff(Insert, "xxdef")), diffs);
+  assertEquals("diff_cleanupSemantic: No overlap elimination.",
+               diffList(Diff(Delete, "abcxx"), Diff(Insert, "xxdef")), diffs);
 
   diffs = diffList(Diff(Delete, "abcxxx"), Diff(Insert, "xxxdef"));
   dmp.diff_cleanupSemantic(diffs);
-  assertEquals("diff_cleanupSemantic: Overlap elimination.", diffList(Diff(Delete, "abc"), Diff(Equal, "xxx"), Diff(Insert, "def")), diffs);
+  assertEquals(
+      "diff_cleanupSemantic: Overlap elimination.",
+      diffList(Diff(Delete, "abc"), Diff(Equal, "xxx"), Diff(Insert, "def")),
+      diffs);
 
   diffs = diffList(Diff(Delete, "xxxabc"), Diff(Insert, "defxxx"));
   dmp.diff_cleanupSemantic(diffs);
-  assertEquals("diff_cleanupSemantic: Reverse overlap elimination.", diffList(Diff(Insert, "def"), Diff(Equal, "xxx"), Diff(Delete, "abc")), diffs);
+  assertEquals(
+      "diff_cleanupSemantic: Reverse overlap elimination.",
+      diffList(Diff(Insert, "def"), Diff(Equal, "xxx"), Diff(Delete, "abc")),
+      diffs);
 
-  diffs = diffList(Diff(Delete, "abcd1212"), Diff(Insert, "1212efghi"), Diff(Equal, "----"), Diff(Delete, "A3"), Diff(Insert, "3BC"));
+  diffs =
+      diffList(Diff(Delete, "abcd1212"), Diff(Insert, "1212efghi"),
+               Diff(Equal, "----"), Diff(Delete, "A3"), Diff(Insert, "3BC"));
   dmp.diff_cleanupSemantic(diffs);
-  assertEquals("diff_cleanupSemantic: Two overlap eliminations.", diffList(Diff(Delete, "abcd"), Diff(Equal, "1212"), Diff(Insert, "efghi"), Diff(Equal, "----"), Diff(Delete, "A"), Diff(Equal, "3"), Diff(Insert, "BC")), diffs);
+  assertEquals(
+      "diff_cleanupSemantic: Two overlap eliminations.",
+      diffList(Diff(Delete, "abcd"), Diff(Equal, "1212"), Diff(Insert, "efghi"),
+               Diff(Equal, "----"), Diff(Delete, "A"), Diff(Equal, "3"),
+               Diff(Insert, "BC")),
+      diffs);
 }
 
 void diff_match_patch_test::testDiffCleanupEfficiency() {
@@ -375,45 +509,73 @@ void diff_match_patch_test::testDiffCleanupEfficiency() {
   dmp.diff_cleanupEfficiency(diffs);
   assertEquals("diff_cleanupEfficiency: Null case.", diffList(), diffs);
 
-  diffs = diffList(Diff(Delete, "ab"), Diff(Insert, "12"), Diff(Equal, "wxyz"), Diff(Delete, "cd"), Diff(Insert, "34"));
+  diffs = diffList(Diff(Delete, "ab"), Diff(Insert, "12"), Diff(Equal, "wxyz"),
+                   Diff(Delete, "cd"), Diff(Insert, "34"));
   dmp.diff_cleanupEfficiency(diffs);
-  assertEquals("diff_cleanupEfficiency: No elimination.", diffList(Diff(Delete, "ab"), Diff(Insert, "12"), Diff(Equal, "wxyz"), Diff(Delete, "cd"), Diff(Insert, "34")), diffs);
+  assertEquals(
+      "diff_cleanupEfficiency: No elimination.",
+      diffList(Diff(Delete, "ab"), Diff(Insert, "12"), Diff(Equal, "wxyz"),
+               Diff(Delete, "cd"), Diff(Insert, "34")),
+      diffs);
 
-  diffs = diffList(Diff(Delete, "ab"), Diff(Insert, "12"), Diff(Equal, "xyz"), Diff(Delete, "cd"), Diff(Insert, "34"));
+  diffs = diffList(Diff(Delete, "ab"), Diff(Insert, "12"), Diff(Equal, "xyz"),
+                   Diff(Delete, "cd"), Diff(Insert, "34"));
   dmp.diff_cleanupEfficiency(diffs);
-  assertEquals("diff_cleanupEfficiency: Four-edit elimination.", diffList(Diff(Delete, "abxyzcd"), Diff(Insert, "12xyz34")), diffs);
+  assertEquals("diff_cleanupEfficiency: Four-edit elimination.",
+               diffList(Diff(Delete, "abxyzcd"), Diff(Insert, "12xyz34")),
+               diffs);
 
-  diffs = diffList(Diff(Insert, "12"), Diff(Equal, "x"), Diff(Delete, "cd"), Diff(Insert, "34"));
+  diffs = diffList(Diff(Insert, "12"), Diff(Equal, "x"), Diff(Delete, "cd"),
+                   Diff(Insert, "34"));
   dmp.diff_cleanupEfficiency(diffs);
-  assertEquals("diff_cleanupEfficiency: Three-edit elimination.", diffList(Diff(Delete, "xcd"), Diff(Insert, "12x34")), diffs);
+  assertEquals("diff_cleanupEfficiency: Three-edit elimination.",
+               diffList(Diff(Delete, "xcd"), Diff(Insert, "12x34")), diffs);
 
-  diffs = diffList(Diff(Delete, "ab"), Diff(Insert, "12"), Diff(Equal, "xy"), Diff(Insert, "34"), Diff(Equal, "z"), Diff(Delete, "cd"), Diff(Insert, "56"));
+  diffs = diffList(Diff(Delete, "ab"), Diff(Insert, "12"), Diff(Equal, "xy"),
+                   Diff(Insert, "34"), Diff(Equal, "z"), Diff(Delete, "cd"),
+                   Diff(Insert, "56"));
   dmp.diff_cleanupEfficiency(diffs);
-  assertEquals("diff_cleanupEfficiency: Backpass elimination.", diffList(Diff(Delete, "abxyzcd"), Diff(Insert, "12xy34z56")), diffs);
+  assertEquals("diff_cleanupEfficiency: Backpass elimination.",
+               diffList(Diff(Delete, "abxyzcd"), Diff(Insert, "12xy34z56")),
+               diffs);
 
   dmp.Diff_EditCost = 5;
-  diffs = diffList(Diff(Delete, "ab"), Diff(Insert, "12"), Diff(Equal, "wxyz"), Diff(Delete, "cd"), Diff(Insert, "34"));
+  diffs = diffList(Diff(Delete, "ab"), Diff(Insert, "12"), Diff(Equal, "wxyz"),
+                   Diff(Delete, "cd"), Diff(Insert, "34"));
   dmp.diff_cleanupEfficiency(diffs);
-  assertEquals("diff_cleanupEfficiency: High cost elimination.", diffList(Diff(Delete, "abwxyzcd"), Diff(Insert, "12wxyz34")), diffs);
+  assertEquals("diff_cleanupEfficiency: High cost elimination.",
+               diffList(Diff(Delete, "abwxyzcd"), Diff(Insert, "12wxyz34")),
+               diffs);
   dmp.Diff_EditCost = 4;
 }
 
 void diff_match_patch_test::testDiffPrettyHtml() {
   // Pretty print.
-  QList<Diff> diffs = diffList(Diff(Equal, "a\n"), Diff(Delete, "<B>b</B>"), Diff(Insert, "c&d"));
-  assertEquals("diff_prettyHtml:", "<span>a&para;<br></span><del style=\"background:#ffe6e6;\">&lt;B&gt;b&lt;/B&gt;</del><ins style=\"background:#e6ffe6;\">c&amp;d</ins>", dmp.diff_prettyHtml(diffs));
+  QList<Diff> diffs = diffList(Diff(Equal, "a\n"), Diff(Delete, "<B>b</B>"),
+                               Diff(Insert, "c&d"));
+  assertEquals("diff_prettyHtml:",
+               "<span>a&para;<br></span><del "
+               "style=\"background:#ffe6e6;\">&lt;B&gt;b&lt;/B&gt;</del><ins "
+               "style=\"background:#e6ffe6;\">c&amp;d</ins>",
+               dmp.diff_prettyHtml(diffs));
 }
 
 void diff_match_patch_test::testDiffText() {
   // Compute the source and destination texts.
-  QList<Diff> diffs = diffList(Diff(Equal, "jump"), Diff(Delete, "s"), Diff(Insert, "ed"), Diff(Equal, " over "), Diff(Delete, "the"), Diff(Insert, "a"), Diff(Equal, " lazy"));
+  QList<Diff> diffs =
+      diffList(Diff(Equal, "jump"), Diff(Delete, "s"), Diff(Insert, "ed"),
+               Diff(Equal, " over "), Diff(Delete, "the"), Diff(Insert, "a"),
+               Diff(Equal, " lazy"));
   assertEquals("diff_text1:", "jumps over the lazy", dmp.diff_text1(diffs));
   assertEquals("diff_text2:", "jumped over a lazy", dmp.diff_text2(diffs));
 }
 
 void diff_match_patch_test::testDiffDelta() {
   // Convert a diff into delta string.
-  QList<Diff> diffs = diffList(Diff(Equal, "jump"), Diff(Delete, "s"), Diff(Insert, "ed"), Diff(Equal, " over "), Diff(Delete, "the"), Diff(Insert, "a"), Diff(Equal, " lazy"), Diff(Insert, "old dog"));
+  QList<Diff> diffs =
+      diffList(Diff(Equal, "jump"), Diff(Delete, "s"), Diff(Insert, "ed"),
+               Diff(Equal, " over "), Diff(Delete, "the"), Diff(Insert, "a"),
+               Diff(Equal, " lazy"), Diff(Insert, "old dog"));
   QString text1 = dmp.diff_text1(diffs);
   assertEquals("diff_text1: Base text.", "jumps over the lazy", text1);
 
@@ -421,7 +583,8 @@ void diff_match_patch_test::testDiffDelta() {
   assertEquals("diff_toDelta:", "=4\t-1\t+ed\t=6\t-3\t+a\t=5\t+old dog", delta);
 
   // Convert delta string into a diff.
-  assertEquals("diff_fromDelta: Normal.", diffs, dmp.diff_fromDelta(text1, delta));
+  assertEquals("diff_fromDelta: Normal.", diffs,
+               dmp.diff_fromDelta(text1, delta));
 
   // Generates error (19 < 20).
   try {
@@ -450,45 +613,68 @@ void diff_match_patch_test::testDiffDelta() {
   */
 
   // Test deltas with special characters.
-  diffs = diffList(Diff(Equal, QString::fromWCharArray((const wchar_t*) L"\u0680 \000 \t %", 7)), Diff(Delete, QString::fromWCharArray((const wchar_t*) L"\u0681 \001 \n ^", 7)), Diff(Insert, QString::fromWCharArray((const wchar_t*) L"\u0682 \002 \\ |", 7)));
+  diffs = diffList(
+      Diff(Equal,
+           QString::fromWCharArray((const wchar_t *)L"\u0680 \000 \t %", 7)),
+      Diff(Delete,
+           QString::fromWCharArray((const wchar_t *)L"\u0681 \001 \n ^", 7)),
+      Diff(Insert,
+           QString::fromWCharArray((const wchar_t *)L"\u0682 \002 \\ |", 7)));
   text1 = dmp.diff_text1(diffs);
-  assertEquals("diff_text1: Unicode text.", QString::fromWCharArray((const wchar_t*) L"\u0680 \000 \t %\u0681 \001 \n ^", 14), text1);
+  assertEquals("diff_text1: Unicode text.",
+               QString::fromWCharArray(
+                   (const wchar_t *)L"\u0680 \000 \t %\u0681 \001 \n ^", 14),
+               text1);
 
   delta = dmp.diff_toDelta(diffs);
   assertEquals("diff_toDelta: Unicode.", "=7\t-7\t+%DA%82 %02 %5C %7C", delta);
 
-  assertEquals("diff_fromDelta: Unicode.", diffs, dmp.diff_fromDelta(text1, delta));
+  assertEquals("diff_fromDelta: Unicode.", diffs,
+               dmp.diff_fromDelta(text1, delta));
 
   // Verify pool of unchanged characters.
-  diffs = diffList(Diff(Insert, "A-Z a-z 0-9 - _ . ! ~ * ' ( ) ; / ? : @ & = + $ , # "));
+  diffs = diffList(
+      Diff(Insert, "A-Z a-z 0-9 - _ . ! ~ * ' ( ) ; / ? : @ & = + $ , # "));
   QString text2 = dmp.diff_text2(diffs);
-  assertEquals("diff_text2: Unchanged characters.", "A-Z a-z 0-9 - _ . ! ~ * \' ( ) ; / ? : @ & = + $ , # ", text2);
+  assertEquals("diff_text2: Unchanged characters.",
+               "A-Z a-z 0-9 - _ . ! ~ * \' ( ) ; / ? : @ & = + $ , # ", text2);
 
   delta = dmp.diff_toDelta(diffs);
-  assertEquals("diff_toDelta: Unchanged characters.", "+A-Z a-z 0-9 - _ . ! ~ * \' ( ) ; / ? : @ & = + $ , # ", delta);
+  assertEquals("diff_toDelta: Unchanged characters.",
+               "+A-Z a-z 0-9 - _ . ! ~ * \' ( ) ; / ? : @ & = + $ , # ", delta);
 
   // Convert delta string into a diff.
-  assertEquals("diff_fromDelta: Unchanged characters.", diffs, dmp.diff_fromDelta("", delta));
+  assertEquals("diff_fromDelta: Unchanged characters.", diffs,
+               dmp.diff_fromDelta("", delta));
 }
 
 void diff_match_patch_test::testDiffXIndex() {
   // Translate a location in text1 to text2.
-  QList<Diff> diffs = diffList(Diff(Delete, "a"), Diff(Insert, "1234"), Diff(Equal, "xyz"));
-  assertEquals("diff_xIndex: Translation on equality.", 5, dmp.diff_xIndex(diffs, 2));
+  QList<Diff> diffs =
+      diffList(Diff(Delete, "a"), Diff(Insert, "1234"), Diff(Equal, "xyz"));
+  assertEquals("diff_xIndex: Translation on equality.", 5,
+               dmp.diff_xIndex(diffs, 2));
 
   diffs = diffList(Diff(Equal, "a"), Diff(Delete, "1234"), Diff(Equal, "xyz"));
-  assertEquals("diff_xIndex: Translation on deletion.", 1, dmp.diff_xIndex(diffs, 3));
+  assertEquals("diff_xIndex: Translation on deletion.", 1,
+               dmp.diff_xIndex(diffs, 3));
 }
 
 void diff_match_patch_test::testDiffLevenshtein() {
-  QList<Diff> diffs = diffList(Diff(Delete, "abc"), Diff(Insert, "1234"), Diff(Equal, "xyz"));
-  assertEquals("diff_levenshtein: Trailing equality.", 4, dmp.diff_levenshtein(diffs));
+  QList<Diff> diffs =
+      diffList(Diff(Delete, "abc"), Diff(Insert, "1234"), Diff(Equal, "xyz"));
+  assertEquals("diff_levenshtein: Trailing equality.", 4,
+               dmp.diff_levenshtein(diffs));
 
-  diffs = diffList(Diff(Equal, "xyz"), Diff(Delete, "abc"), Diff(Insert, "1234"));
-  assertEquals("diff_levenshtein: Leading equality.", 4, dmp.diff_levenshtein(diffs));
+  diffs =
+      diffList(Diff(Equal, "xyz"), Diff(Delete, "abc"), Diff(Insert, "1234"));
+  assertEquals("diff_levenshtein: Leading equality.", 4,
+               dmp.diff_levenshtein(diffs));
 
-  diffs = diffList(Diff(Delete, "abc"), Diff(Equal, "xyz"), Diff(Insert, "1234"));
-  assertEquals("diff_levenshtein: Middle equality.", 7, dmp.diff_levenshtein(diffs));
+  diffs =
+      diffList(Diff(Delete, "abc"), Diff(Equal, "xyz"), Diff(Insert, "1234"));
+  assertEquals("diff_levenshtein: Middle equality.", 7,
+               dmp.diff_levenshtein(diffs));
 }
 
 void diff_match_patch_test::testDiffBisect() {
@@ -498,8 +684,11 @@ void diff_match_patch_test::testDiffBisect() {
   // Since the resulting diff hasn't been normalized, it would be ok if
   // the insertion and deletion pairs are swapped.
   // If the order changes, tweak this test as required.
-  QList<Diff> diffs = diffList(Diff(Delete, "c"), Diff(Insert, "m"), Diff(Equal, "a"), Diff(Delete, "t"), Diff(Insert, "p"));
-  assertEquals("diff_bisect: Normal.", diffs, dmp.diff_bisect(a, b, std::numeric_limits<clock_t>::max()));
+  QList<Diff> diffs =
+      diffList(Diff(Delete, "c"), Diff(Insert, "m"), Diff(Equal, "a"),
+               Diff(Delete, "t"), Diff(Insert, "p"));
+  assertEquals("diff_bisect: Normal.", diffs,
+               dmp.diff_bisect(a, b, std::numeric_limits<clock_t>::max()));
 
   // Timeout.
   diffs = diffList(Diff(Delete, "cat"), Diff(Insert, "map"));
@@ -512,48 +701,88 @@ void diff_match_patch_test::testDiffMain() {
   assertEquals("diff_main: Null case.", diffs, dmp.diff_main("", "", false));
 
   diffs = diffList(Diff(Equal, "abc"));
-  assertEquals("diff_main: Equality.", diffs, dmp.diff_main("abc", "abc", false));
+  assertEquals("diff_main: Equality.", diffs,
+               dmp.diff_main("abc", "abc", false));
 
   diffs = diffList(Diff(Equal, "ab"), Diff(Insert, "123"), Diff(Equal, "c"));
-  assertEquals("diff_main: Simple insertion.", diffs, dmp.diff_main("abc", "ab123c", false));
+  assertEquals("diff_main: Simple insertion.", diffs,
+               dmp.diff_main("abc", "ab123c", false));
 
   diffs = diffList(Diff(Equal, "a"), Diff(Delete, "123"), Diff(Equal, "bc"));
-  assertEquals("diff_main: Simple deletion.", diffs, dmp.diff_main("a123bc", "abc", false));
+  assertEquals("diff_main: Simple deletion.", diffs,
+               dmp.diff_main("a123bc", "abc", false));
 
-  diffs = diffList(Diff(Equal, "a"), Diff(Insert, "123"), Diff(Equal, "b"), Diff(Insert, "456"), Diff(Equal, "c"));
-  assertEquals("diff_main: Two insertions.", diffs, dmp.diff_main("abc", "a123b456c", false));
+  diffs = diffList(Diff(Equal, "a"), Diff(Insert, "123"), Diff(Equal, "b"),
+                   Diff(Insert, "456"), Diff(Equal, "c"));
+  assertEquals("diff_main: Two insertions.", diffs,
+               dmp.diff_main("abc", "a123b456c", false));
 
-  diffs = diffList(Diff(Equal, "a"), Diff(Delete, "123"), Diff(Equal, "b"), Diff(Delete, "456"), Diff(Equal, "c"));
-  assertEquals("diff_main: Two deletions.", diffs, dmp.diff_main("a123b456c", "abc", false));
+  diffs = diffList(Diff(Equal, "a"), Diff(Delete, "123"), Diff(Equal, "b"),
+                   Diff(Delete, "456"), Diff(Equal, "c"));
+  assertEquals("diff_main: Two deletions.", diffs,
+               dmp.diff_main("a123b456c", "abc", false));
 
   // Perform a real diff.
   // Switch off the timeout.
   dmp.Diff_Timeout = 0;
   diffs = diffList(Diff(Delete, "a"), Diff(Insert, "b"));
-  assertEquals("diff_main: Simple case #1.", diffs, dmp.diff_main("a", "b", false));
+  assertEquals("diff_main: Simple case #1.", diffs,
+               dmp.diff_main("a", "b", false));
 
-  diffs = diffList(Diff(Delete, "Apple"), Diff(Insert, "Banana"), Diff(Equal, "s are a"), Diff(Insert, "lso"), Diff(Equal, " fruit."));
-  assertEquals("diff_main: Simple case #2.", diffs, dmp.diff_main("Apples are a fruit.", "Bananas are also fruit.", false));
+  diffs = diffList(Diff(Delete, "Apple"), Diff(Insert, "Banana"),
+                   Diff(Equal, "s are a"), Diff(Insert, "lso"),
+                   Diff(Equal, " fruit."));
+  assertEquals(
+      "diff_main: Simple case #2.", diffs,
+      dmp.diff_main("Apples are a fruit.", "Bananas are also fruit.", false));
 
-  diffs = diffList(Diff(Delete, "a"), Diff(Insert, QString::fromWCharArray((const wchar_t*) L"\u0680", 1)), Diff(Equal, "x"), Diff(Delete, "\t"), Diff(Insert, QString::fromWCharArray((const wchar_t*) L"\000", 1)));
-  assertEquals("diff_main: Simple case #3.", diffs, dmp.diff_main("ax\t", QString::fromWCharArray((const wchar_t*) L"\u0680x\000", 3), false));
+  diffs = diffList(
+      Diff(Delete, "a"),
+      Diff(Insert, QString::fromWCharArray((const wchar_t *)L"\u0680", 1)),
+      Diff(Equal, "x"), Diff(Delete, "\t"),
+      Diff(Insert, QString::fromWCharArray((const wchar_t *)L"\000", 1)));
+  assertEquals(
+      "diff_main: Simple case #3.", diffs,
+      dmp.diff_main("ax\t",
+                    QString::fromWCharArray((const wchar_t *)L"\u0680x\000", 3),
+                    false));
 
-  diffs = diffList(Diff(Delete, "1"), Diff(Equal, "a"), Diff(Delete, "y"), Diff(Equal, "b"), Diff(Delete, "2"), Diff(Insert, "xab"));
-  assertEquals("diff_main: Overlap #1.", diffs, dmp.diff_main("1ayb2", "abxab", false));
+  diffs = diffList(Diff(Delete, "1"), Diff(Equal, "a"), Diff(Delete, "y"),
+                   Diff(Equal, "b"), Diff(Delete, "2"), Diff(Insert, "xab"));
+  assertEquals("diff_main: Overlap #1.", diffs,
+               dmp.diff_main("1ayb2", "abxab", false));
 
-  diffs = diffList(Diff(Insert, "xaxcx"), Diff(Equal, "abc"), Diff(Delete, "y"));
-  assertEquals("diff_main: Overlap #2.", diffs, dmp.diff_main("abcy", "xaxcxabc", false));
+  diffs =
+      diffList(Diff(Insert, "xaxcx"), Diff(Equal, "abc"), Diff(Delete, "y"));
+  assertEquals("diff_main: Overlap #2.", diffs,
+               dmp.diff_main("abcy", "xaxcxabc", false));
 
-  diffs = diffList(Diff(Delete, "ABCD"), Diff(Equal, "a"), Diff(Delete, "="), Diff(Insert, "-"), Diff(Equal, "bcd"), Diff(Delete, "="), Diff(Insert, "-"), Diff(Equal, "efghijklmnopqrs"), Diff(Delete, "EFGHIJKLMNOefg"));
-  assertEquals("diff_main: Overlap #3.", diffs, dmp.diff_main("ABCDa=bcd=efghijklmnopqrsEFGHIJKLMNOefg", "a-bcd-efghijklmnopqrs", false));
+  diffs = diffList(Diff(Delete, "ABCD"), Diff(Equal, "a"), Diff(Delete, "="),
+                   Diff(Insert, "-"), Diff(Equal, "bcd"), Diff(Delete, "="),
+                   Diff(Insert, "-"), Diff(Equal, "efghijklmnopqrs"),
+                   Diff(Delete, "EFGHIJKLMNOefg"));
+  assertEquals("diff_main: Overlap #3.", diffs,
+               dmp.diff_main("ABCDa=bcd=efghijklmnopqrsEFGHIJKLMNOefg",
+                             "a-bcd-efghijklmnopqrs", false));
 
-  diffs = diffList(Diff(Insert, " "), Diff(Equal, "a"), Diff(Insert, "nd"), Diff(Equal, " [[Pennsylvania]]"), Diff(Delete, " and [[New"));
-  assertEquals("diff_main: Large equality.", diffs, dmp.diff_main("a [[Pennsylvania]] and [[New", " and [[Pennsylvania]]", false));
+  diffs =
+      diffList(Diff(Insert, " "), Diff(Equal, "a"), Diff(Insert, "nd"),
+               Diff(Equal, " [[Pennsylvania]]"), Diff(Delete, " and [[New"));
+  assertEquals("diff_main: Large equality.", diffs,
+               dmp.diff_main("a [[Pennsylvania]] and [[New",
+                             " and [[Pennsylvania]]", false));
 
   dmp.Diff_Timeout = 0.1f;  // 100ms
-  // This test may 'fail' on extremely fast computers.  If so, just increase the text lengths.
-  QString a = "`Twas brillig, and the slithy toves\nDid gyre and gimble in the wabe:\nAll mimsy were the borogoves,\nAnd the mome raths outgrabe.\n";
-  QString b = "I am the very model of a modern major general,\nI've information vegetable, animal, and mineral,\nI know the kings of England, and I quote the fights historical,\nFrom Marathon to Waterloo, in order categorical.\n";
+  // This test may 'fail' on extremely fast computers.  If so, just increase the
+  // text lengths.
+  QString a =
+      "`Twas brillig, and the slithy toves\nDid gyre and gimble in the "
+      "wabe:\nAll mimsy were the borogoves,\nAnd the mome raths outgrabe.\n";
+  QString b =
+      "I am the very model of a modern major general,\nI've information "
+      "vegetable, animal, and mineral,\nI know the kings of England, and I "
+      "quote the fights historical,\nFrom Marathon to Waterloo, in order "
+      "categorical.\n";
   // Increase the text lengths by 1024 times to ensure a timeout.
   for (int x = 0; x < 10; x++) {
     a = a + a;
@@ -563,27 +792,41 @@ void diff_match_patch_test::testDiffMain() {
   dmp.diff_main(a, b);
   clock_t endTime = clock();
   // Test that we took at least the timeout period.
-  assertTrue("diff_main: Timeout min.", dmp.Diff_Timeout * CLOCKS_PER_SEC <= endTime - startTime);
+  assertTrue("diff_main: Timeout min.",
+             dmp.Diff_Timeout * CLOCKS_PER_SEC <= endTime - startTime);
   // Test that we didn't take forever (be forgiving).
   // Theoretically this test could fail very occasionally if the
   // OS task swaps or locks up for a second at the wrong moment.
   // Java seems to overrun by ~80% (compared with 10% for other languages).
   // Therefore use an upper limit of 0.5s instead of 0.2s.
-  assertTrue("diff_main: Timeout max.", dmp.Diff_Timeout * CLOCKS_PER_SEC * 2 > endTime - startTime);
+  assertTrue("diff_main: Timeout max.",
+             dmp.Diff_Timeout * CLOCKS_PER_SEC * 2 > endTime - startTime);
   dmp.Diff_Timeout = 0;
 
   // Test the linemode speedup.
   // Must be long to pass the 100 char cutoff.
-  a = "1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n";
-  b = "abcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\n";
-  assertEquals("diff_main: Simple line-mode.", dmp.diff_main(a, b, true), dmp.diff_main(a, b, false));
+  a = "1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n"
+      "1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n"
+      "1234567890\n";
+  b = "abcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\n"
+      "abcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\nabcdefghij\n"
+      "abcdefghij\n";
+  assertEquals("diff_main: Simple line-mode.", dmp.diff_main(a, b, true),
+               dmp.diff_main(a, b, false));
 
-  a = "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
-  b = "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij";
-  assertEquals("diff_main: Single line-mode.", dmp.diff_main(a, b, true), dmp.diff_main(a, b, false));
+  a = "123456789012345678901234567890123456789012345678901234567890123456789012"
+      "3456789012345678901234567890123456789012345678901234567890";
+  b = "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijab"
+      "cdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij";
+  assertEquals("diff_main: Single line-mode.", dmp.diff_main(a, b, true),
+               dmp.diff_main(a, b, false));
 
-  a = "1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n";
-  b = "abcdefghij\n1234567890\n1234567890\n1234567890\nabcdefghij\n1234567890\n1234567890\n1234567890\nabcdefghij\n1234567890\n1234567890\n1234567890\nabcdefghij\n";
+  a = "1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n"
+      "1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n1234567890\n"
+      "1234567890\n";
+  b = "abcdefghij\n1234567890\n1234567890\n1234567890\nabcdefghij\n1234567890\n"
+      "1234567890\n1234567890\nabcdefghij\n1234567890\n1234567890\n1234567890\n"
+      "abcdefghij\n";
   QStringList texts_linemode = diff_rebuildtexts(dmp.diff_main(a, b, true));
   QStringList texts_textmode = diff_rebuildtexts(dmp.diff_main(a, b, false));
   assertEquals("diff_main: Overlap line-mode.", texts_textmode, texts_linemode);
@@ -592,14 +835,12 @@ void diff_match_patch_test::testDiffMain() {
   try {
     dmp.diff_main(NULL, NULL);
     assertFalse("diff_main: Null inputs.", true);
-  } catch (const char* ex) {
+  } catch (const char *ex) {
     // Exception expected.
   }
 }
 
-
 //  MATCH TEST FUNCTIONS
-
 
 void diff_match_patch_test::testMatchAlphabet() {
   // Initialise the bitmasks for Bitap.
@@ -613,80 +854,100 @@ void diff_match_patch_test::testMatchAlphabet() {
   bitmask.insert('a', 37);
   bitmask.insert('b', 18);
   bitmask.insert('c', 8);
-  assertEquals("match_alphabet: Duplicates.", bitmask, dmp.match_alphabet("abcaba"));
+  assertEquals("match_alphabet: Duplicates.", bitmask,
+               dmp.match_alphabet("abcaba"));
 }
 
 void diff_match_patch_test::testMatchBitap() {
   // Bitap algorithm.
   dmp.Match_Distance = 100;
   dmp.Match_Threshold = 0.5f;
-  assertEquals("match_bitap: Exact match #1.", 5, dmp.match_bitap("abcdefghijk", "fgh", 5));
+  assertEquals("match_bitap: Exact match #1.", 5,
+               dmp.match_bitap("abcdefghijk", "fgh", 5));
 
-  assertEquals("match_bitap: Exact match #2.", 5, dmp.match_bitap("abcdefghijk", "fgh", 0));
+  assertEquals("match_bitap: Exact match #2.", 5,
+               dmp.match_bitap("abcdefghijk", "fgh", 0));
 
-  assertEquals("match_bitap: Fuzzy match #1.", 4, dmp.match_bitap("abcdefghijk", "efxhi", 0));
+  assertEquals("match_bitap: Fuzzy match #1.", 4,
+               dmp.match_bitap("abcdefghijk", "efxhi", 0));
 
-  assertEquals("match_bitap: Fuzzy match #2.", 2, dmp.match_bitap("abcdefghijk", "cdefxyhijk", 5));
+  assertEquals("match_bitap: Fuzzy match #2.", 2,
+               dmp.match_bitap("abcdefghijk", "cdefxyhijk", 5));
 
-  assertEquals("match_bitap: Fuzzy match #3.", -1, dmp.match_bitap("abcdefghijk", "bxy", 1));
+  assertEquals("match_bitap: Fuzzy match #3.", -1,
+               dmp.match_bitap("abcdefghijk", "bxy", 1));
 
-  assertEquals("match_bitap: Overflow.", 2, dmp.match_bitap("123456789xx0", "3456789x0", 2));
+  assertEquals("match_bitap: Overflow.", 2,
+               dmp.match_bitap("123456789xx0", "3456789x0", 2));
 
-  assertEquals("match_bitap: Before start match.", 0, dmp.match_bitap("abcdef", "xxabc", 4));
+  assertEquals("match_bitap: Before start match.", 0,
+               dmp.match_bitap("abcdef", "xxabc", 4));
 
-  assertEquals("match_bitap: Beyond end match.", 3, dmp.match_bitap("abcdef", "defyy", 4));
+  assertEquals("match_bitap: Beyond end match.", 3,
+               dmp.match_bitap("abcdef", "defyy", 4));
 
-  assertEquals("match_bitap: Oversized pattern.", 0, dmp.match_bitap("abcdef", "xabcdefy", 0));
+  assertEquals("match_bitap: Oversized pattern.", 0,
+               dmp.match_bitap("abcdef", "xabcdefy", 0));
 
   dmp.Match_Threshold = 0.4f;
-  assertEquals("match_bitap: Threshold #1.", 4, dmp.match_bitap("abcdefghijk", "efxyhi", 1));
+  assertEquals("match_bitap: Threshold #1.", 4,
+               dmp.match_bitap("abcdefghijk", "efxyhi", 1));
 
   dmp.Match_Threshold = 0.3f;
-  assertEquals("match_bitap: Threshold #2.", -1, dmp.match_bitap("abcdefghijk", "efxyhi", 1));
+  assertEquals("match_bitap: Threshold #2.", -1,
+               dmp.match_bitap("abcdefghijk", "efxyhi", 1));
 
   dmp.Match_Threshold = 0.0f;
-  assertEquals("match_bitap: Threshold #3.", 1, dmp.match_bitap("abcdefghijk", "bcdef", 1));
+  assertEquals("match_bitap: Threshold #3.", 1,
+               dmp.match_bitap("abcdefghijk", "bcdef", 1));
 
   dmp.Match_Threshold = 0.5f;
-  assertEquals("match_bitap: Multiple select #1.", 0, dmp.match_bitap("abcdexyzabcde", "abccde", 3));
+  assertEquals("match_bitap: Multiple select #1.", 0,
+               dmp.match_bitap("abcdexyzabcde", "abccde", 3));
 
-  assertEquals("match_bitap: Multiple select #2.", 8, dmp.match_bitap("abcdexyzabcde", "abccde", 5));
+  assertEquals("match_bitap: Multiple select #2.", 8,
+               dmp.match_bitap("abcdexyzabcde", "abccde", 5));
 
   dmp.Match_Distance = 10;  // Strict location.
-  assertEquals("match_bitap: Distance test #1.", -1, dmp.match_bitap("abcdefghijklmnopqrstuvwxyz", "abcdefg", 24));
+  assertEquals("match_bitap: Distance test #1.", -1,
+               dmp.match_bitap("abcdefghijklmnopqrstuvwxyz", "abcdefg", 24));
 
-  assertEquals("match_bitap: Distance test #2.", 0, dmp.match_bitap("abcdefghijklmnopqrstuvwxyz", "abcdxxefg", 1));
+  assertEquals("match_bitap: Distance test #2.", 0,
+               dmp.match_bitap("abcdefghijklmnopqrstuvwxyz", "abcdxxefg", 1));
 
   dmp.Match_Distance = 1000;  // Loose location.
-  assertEquals("match_bitap: Distance test #3.", 0, dmp.match_bitap("abcdefghijklmnopqrstuvwxyz", "abcdefg", 24));
+  assertEquals("match_bitap: Distance test #3.", 0,
+               dmp.match_bitap("abcdefghijklmnopqrstuvwxyz", "abcdefg", 24));
 }
 
 void diff_match_patch_test::testMatchMain() {
   // Full match.
-  assertEquals("match_main: Equality.", 0, dmp.match_main("abcdef", "abcdef", 1000));
+  assertEquals("match_main: Equality.", 0,
+               dmp.match_main("abcdef", "abcdef", 1000));
 
   assertEquals("match_main: Null text.", -1, dmp.match_main("", "abcdef", 1));
 
   assertEquals("match_main: Null pattern.", 3, dmp.match_main("abcdef", "", 3));
 
-  assertEquals("match_main: Exact match.", 3, dmp.match_main("abcdef", "de", 3));
+  assertEquals("match_main: Exact match.", 3,
+               dmp.match_main("abcdef", "de", 3));
 
   dmp.Match_Threshold = 0.7f;
-  assertEquals("match_main: Complex match.", 4, dmp.match_main("I am the very model of a modern major general.", " that berry ", 5));
+  assertEquals("match_main: Complex match.", 4,
+               dmp.match_main("I am the very model of a modern major general.",
+                              " that berry ", 5));
   dmp.Match_Threshold = 0.5f;
 
   // Test null inputs.
   try {
     dmp.match_main(NULL, NULL, 0);
     assertFalse("match_main: Null inputs.", true);
-  } catch (const char* ex) {
+  } catch (const char *ex) {
     // Exception expected.
   }
 }
 
-
 //  PATCH TEST FUNCTIONS
-
 
 void diff_match_patch_test::testPatchObj() {
   // Patch Object.
@@ -695,22 +956,32 @@ void diff_match_patch_test::testPatchObj() {
   p.start2 = 21;
   p.length1 = 18;
   p.length2 = 17;
-  p.diffs = diffList(Diff(Equal, "jump"), Diff(Delete, "s"), Diff(Insert, "ed"), Diff(Equal, " over "), Diff(Delete, "the"), Diff(Insert, "a"), Diff(Equal, "\nlaz"));
-  QString strp = "@@ -21,18 +22,17 @@\n jump\n-s\n+ed\n  over \n-the\n+a\n %0Alaz\n";
+  p.diffs = diffList(Diff(Equal, "jump"), Diff(Delete, "s"), Diff(Insert, "ed"),
+                     Diff(Equal, " over "), Diff(Delete, "the"),
+                     Diff(Insert, "a"), Diff(Equal, "\nlaz"));
+  QString strp =
+      "@@ -21,18 +22,17 @@\n jump\n-s\n+ed\n  over \n-the\n+a\n %0Alaz\n";
   assertEquals("Patch: toString.", strp, p.toString());
 }
 
 void diff_match_patch_test::testPatchFromText() {
   assertTrue("patch_fromText: #0.", dmp.patch_fromText("").isEmpty());
 
-  QString strp = "@@ -21,18 +22,17 @@\n jump\n-s\n+ed\n  over \n-the\n+a\n %0Alaz\n";
-  assertEquals("patch_fromText: #1.", strp, dmp.patch_fromText(strp).value(0).toString());
+  QString strp =
+      "@@ -21,18 +22,17 @@\n jump\n-s\n+ed\n  over \n-the\n+a\n %0Alaz\n";
+  assertEquals("patch_fromText: #1.", strp,
+               dmp.patch_fromText(strp).value(0).toString());
 
-  assertEquals("patch_fromText: #2.", "@@ -1 +1 @@\n-a\n+b\n", dmp.patch_fromText("@@ -1 +1 @@\n-a\n+b\n").value(0).toString());
+  assertEquals("patch_fromText: #2.", "@@ -1 +1 @@\n-a\n+b\n",
+               dmp.patch_fromText("@@ -1 +1 @@\n-a\n+b\n").value(0).toString());
 
-  assertEquals("patch_fromText: #3.", "@@ -1,3 +0,0 @@\n-abc\n", dmp.patch_fromText("@@ -1,3 +0,0 @@\n-abc\n").value(0).toString());
+  assertEquals(
+      "patch_fromText: #3.", "@@ -1,3 +0,0 @@\n-abc\n",
+      dmp.patch_fromText("@@ -1,3 +0,0 @@\n-abc\n").value(0).toString());
 
-  assertEquals("patch_fromText: #4.", "@@ -0,0 +1,3 @@\n+abc\n", dmp.patch_fromText("@@ -0,0 +1,3 @@\n+abc\n").value(0).toString());
+  assertEquals(
+      "patch_fromText: #4.", "@@ -0,0 +1,3 @@\n+abc\n",
+      dmp.patch_fromText("@@ -0,0 +1,3 @@\n+abc\n").value(0).toString());
 
   // Generates error.
   try {
@@ -722,12 +993,15 @@ void diff_match_patch_test::testPatchFromText() {
 }
 
 void diff_match_patch_test::testPatchToText() {
-  QString strp = "@@ -21,18 +22,17 @@\n jump\n-s\n+ed\n  over \n-the\n+a\n  laz\n";
+  QString strp =
+      "@@ -21,18 +22,17 @@\n jump\n-s\n+ed\n  over \n-the\n+a\n  laz\n";
   QList<Patch> patches;
   patches = dmp.patch_fromText(strp);
   assertEquals("patch_toText: Single", strp, dmp.patch_toText(patches));
 
-  strp = "@@ -1,9 +1,9 @@\n-f\n+F\n oo+fooba\n@@ -7,9 +7,9 @@\n obar\n-,\n+.\n  tes\n";
+  strp =
+      "@@ -1,9 +1,9 @@\n-f\n+F\n oo+fooba\n@@ -7,9 +7,9 @@\n obar\n-,\n+.\n  "
+      "tes\n";
   patches = dmp.patch_fromText(strp);
   assertEquals("patch_toText: Dual", strp, dmp.patch_toText(patches));
 }
@@ -737,19 +1011,27 @@ void diff_match_patch_test::testPatchAddContext() {
   Patch p;
   p = dmp.patch_fromText("@@ -21,4 +21,10 @@\n-jump\n+somersault\n").value(0);
   dmp.patch_addContext(p, "The quick brown fox jumps over the lazy dog.");
-  assertEquals("patch_addContext: Simple case.", "@@ -17,12 +17,18 @@\n fox \n-jump\n+somersault\n s ov\n", p.toString());
+  assertEquals("patch_addContext: Simple case.",
+               "@@ -17,12 +17,18 @@\n fox \n-jump\n+somersault\n s ov\n",
+               p.toString());
 
   p = dmp.patch_fromText("@@ -21,4 +21,10 @@\n-jump\n+somersault\n").value(0);
   dmp.patch_addContext(p, "The quick brown fox jumps.");
-  assertEquals("patch_addContext: Not enough trailing context.", "@@ -17,10 +17,16 @@\n fox \n-jump\n+somersault\n s.\n", p.toString());
+  assertEquals("patch_addContext: Not enough trailing context.",
+               "@@ -17,10 +17,16 @@\n fox \n-jump\n+somersault\n s.\n",
+               p.toString());
 
   p = dmp.patch_fromText("@@ -3 +3,2 @@\n-e\n+at\n").value(0);
   dmp.patch_addContext(p, "The quick brown fox jumps.");
-  assertEquals("patch_addContext: Not enough leading context.", "@@ -1,7 +1,8 @@\n Th\n-e\n+at\n  qui\n", p.toString());
+  assertEquals("patch_addContext: Not enough leading context.",
+               "@@ -1,7 +1,8 @@\n Th\n-e\n+at\n  qui\n", p.toString());
 
   p = dmp.patch_fromText("@@ -3 +3,2 @@\n-e\n+at\n").value(0);
-  dmp.patch_addContext(p, "The quick brown fox jumps.  The quick brown fox crashes.");
-  assertEquals("patch_addContext: Ambiguity.", "@@ -1,27 +1,28 @@\n Th\n-e\n+at\n  quick brown fox jumps. \n", p.toString());
+  dmp.patch_addContext(
+      p, "The quick brown fox jumps.  The quick brown fox crashes.");
+  assertEquals("patch_addContext: Ambiguity.",
+               "@@ -1,27 +1,28 @@\n Th\n-e\n+at\n  quick brown fox jumps. \n",
+               p.toString());
 }
 
 void diff_match_patch_test::testPatchMake() {
@@ -759,45 +1041,67 @@ void diff_match_patch_test::testPatchMake() {
 
   QString text1 = "The quick brown fox jumps over the lazy dog.";
   QString text2 = "That quick brown fox jumped over a lazy dog.";
-  QString expectedPatch = "@@ -1,8 +1,7 @@\n Th\n-at\n+e\n  qui\n@@ -21,17 +21,18 @@\n jump\n-ed\n+s\n  over \n-a\n+the\n  laz\n";
-  // The second patch must be "-21,17 +21,18", not "-22,17 +21,18" due to rolling context.
+  QString expectedPatch =
+      "@@ -1,8 +1,7 @@\n Th\n-at\n+e\n  qui\n@@ -21,17 +21,18 @@\n "
+      "jump\n-ed\n+s\n  over \n-a\n+the\n  laz\n";
+  // The second patch must be "-21,17 +21,18", not "-22,17 +21,18" due to
+  // rolling context.
   patches = dmp.patch_make(text2, text1);
-  assertEquals("patch_make: Text2+Text1 inputs", expectedPatch, dmp.patch_toText(patches));
+  assertEquals("patch_make: Text2+Text1 inputs", expectedPatch,
+               dmp.patch_toText(patches));
 
-  expectedPatch = "@@ -1,11 +1,12 @@\n Th\n-e\n+at\n  quick b\n@@ -22,18 +22,17 @@\n jump\n-s\n+ed\n  over \n-the\n+a\n  laz\n";
+  expectedPatch =
+      "@@ -1,11 +1,12 @@\n Th\n-e\n+at\n  quick b\n@@ -22,18 +22,17 @@\n "
+      "jump\n-s\n+ed\n  over \n-the\n+a\n  laz\n";
   patches = dmp.patch_make(text1, text2);
-  assertEquals("patch_make: Text1+Text2 inputs", expectedPatch, dmp.patch_toText(patches));
+  assertEquals("patch_make: Text1+Text2 inputs", expectedPatch,
+               dmp.patch_toText(patches));
 
   QList<Diff> diffs = dmp.diff_main(text1, text2, false);
   patches = dmp.patch_make(diffs);
-  assertEquals("patch_make: Diff input", expectedPatch, dmp.patch_toText(patches));
+  assertEquals("patch_make: Diff input", expectedPatch,
+               dmp.patch_toText(patches));
 
   patches = dmp.patch_make(text1, diffs);
-  assertEquals("patch_make: Text1+Diff inputs", expectedPatch, dmp.patch_toText(patches));
+  assertEquals("patch_make: Text1+Diff inputs", expectedPatch,
+               dmp.patch_toText(patches));
 
   patches = dmp.patch_make(text1, text2, diffs);
-  assertEquals("patch_make: Text1+Text2+Diff inputs (deprecated)", expectedPatch, dmp.patch_toText(patches));
+  assertEquals("patch_make: Text1+Text2+Diff inputs (deprecated)",
+               expectedPatch, dmp.patch_toText(patches));
 
   patches = dmp.patch_make("`1234567890-=[]\\;',./", "~!@#$%^&*()_+{}|:\"<>?");
-  assertEquals("patch_toText: Character encoding.", "@@ -1,21 +1,21 @@\n-%601234567890-=%5B%5D%5C;',./\n+~!@#$%25%5E&*()_+%7B%7D%7C:%22%3C%3E?\n", dmp.patch_toText(patches));
+  assertEquals("patch_toText: Character encoding.",
+               "@@ -1,21 +1,21 "
+               "@@\n-%601234567890-=%5B%5D%5C;',./"
+               "\n+~!@#$%25%5E&*()_+%7B%7D%7C:%22%3C%3E?\n",
+               dmp.patch_toText(patches));
 
-  diffs = diffList(Diff(Delete, "`1234567890-=[]\\;',./"), Diff(Insert, "~!@#$%^&*()_+{}|:\"<>?"));
-  assertEquals("patch_fromText: Character decoding.", diffs, dmp.patch_fromText("@@ -1,21 +1,21 @@\n-%601234567890-=%5B%5D%5C;',./\n+~!@#$%25%5E&*()_+%7B%7D%7C:%22%3C%3E?\n").value(0).diffs);
+  diffs = diffList(Diff(Delete, "`1234567890-=[]\\;',./"),
+                   Diff(Insert, "~!@#$%^&*()_+{}|:\"<>?"));
+  assertEquals("patch_fromText: Character decoding.", diffs,
+               dmp.patch_fromText("@@ -1,21 +1,21 "
+                                  "@@\n-%601234567890-=%5B%5D%5C;',./"
+                                  "\n+~!@#$%25%5E&*()_+%7B%7D%7C:%22%3C%3E?\n")
+                   .value(0)
+                   .diffs);
 
   text1 = "";
   for (int x = 0; x < 100; x++) {
     text1 += "abcdef";
   }
   text2 = text1 + "123";
-  expectedPatch = "@@ -573,28 +573,31 @@\n cdefabcdefabcdefabcdefabcdef\n+123\n";
+  expectedPatch =
+      "@@ -573,28 +573,31 @@\n cdefabcdefabcdefabcdefabcdef\n+123\n";
   patches = dmp.patch_make(text1, text2);
-  assertEquals("patch_make: Long string with repeats.", expectedPatch, dmp.patch_toText(patches));
+  assertEquals("patch_make: Long string with repeats.", expectedPatch,
+               dmp.patch_toText(patches));
 
   // Test null inputs.
   try {
     dmp.patch_make(NULL, NULL);
     assertFalse("patch_make: Null inputs.", true);
-  } catch (const char* ex) {
+  } catch (const char *ex) {
     // Exception expected.
   }
 }
@@ -805,40 +1109,74 @@ void diff_match_patch_test::testPatchMake() {
 void diff_match_patch_test::testPatchSplitMax() {
   // Assumes that Match_MaxBits is 32.
   QList<Patch> patches;
-  patches = dmp.patch_make("abcdefghijklmnopqrstuvwxyz01234567890", "XabXcdXefXghXijXklXmnXopXqrXstXuvXwxXyzX01X23X45X67X89X0");
+  patches = dmp.patch_make(
+      "abcdefghijklmnopqrstuvwxyz01234567890",
+      "XabXcdXefXghXijXklXmnXopXqrXstXuvXwxXyzX01X23X45X67X89X0");
   dmp.patch_splitMax(patches);
-  assertEquals("patch_splitMax: #1.", "@@ -1,32 +1,46 @@\n+X\n ab\n+X\n cd\n+X\n ef\n+X\n gh\n+X\n ij\n+X\n kl\n+X\n mn\n+X\n op\n+X\n qr\n+X\n st\n+X\n uv\n+X\n wx\n+X\n yz\n+X\n 012345\n@@ -25,13 +39,18 @@\n zX01\n+X\n 23\n+X\n 45\n+X\n 67\n+X\n 89\n+X\n 0\n", dmp.patch_toText(patches));
+  assertEquals("patch_splitMax: #1.",
+               "@@ -1,32 +1,46 @@\n+X\n ab\n+X\n cd\n+X\n ef\n+X\n gh\n+X\n "
+               "ij\n+X\n kl\n+X\n mn\n+X\n op\n+X\n qr\n+X\n st\n+X\n uv\n+X\n "
+               "wx\n+X\n yz\n+X\n 012345\n@@ -25,13 +39,18 @@\n zX01\n+X\n "
+               "23\n+X\n 45\n+X\n 67\n+X\n 89\n+X\n 0\n",
+               dmp.patch_toText(patches));
 
-  patches = dmp.patch_make("abcdef1234567890123456789012345678901234567890123456789012345678901234567890uvwxyz", "abcdefuvwxyz");
+  patches = dmp.patch_make(
+      "abcdef123456789012345678901234567890123456789012345678901234567890123456"
+      "7890uvwxyz",
+      "abcdefuvwxyz");
   QString oldToText = dmp.patch_toText(patches);
   dmp.patch_splitMax(patches);
   assertEquals("patch_splitMax: #2.", oldToText, dmp.patch_toText(patches));
 
-  patches = dmp.patch_make("1234567890123456789012345678901234567890123456789012345678901234567890", "abc");
+  patches = dmp.patch_make(
+      "1234567890123456789012345678901234567890123456789012345678901234567890",
+      "abc");
   dmp.patch_splitMax(patches);
-  assertEquals("patch_splitMax: #3.", "@@ -1,32 +1,4 @@\n-1234567890123456789012345678\n 9012\n@@ -29,32 +1,4 @@\n-9012345678901234567890123456\n 7890\n@@ -57,14 +1,3 @@\n-78901234567890\n+abc\n", dmp.patch_toText(patches));
+  assertEquals("patch_splitMax: #3.",
+               "@@ -1,32 +1,4 @@\n-1234567890123456789012345678\n 9012\n@@ "
+               "-29,32 +1,4 @@\n-9012345678901234567890123456\n 7890\n@@ "
+               "-57,14 +1,3 @@\n-78901234567890\n+abc\n",
+               dmp.patch_toText(patches));
 
-  patches = dmp.patch_make("abcdefghij , h : 0 , t : 1 abcdefghij , h : 0 , t : 1 abcdefghij , h : 0 , t : 1", "abcdefghij , h : 1 , t : 1 abcdefghij , h : 1 , t : 1 abcdefghij , h : 0 , t : 1");
+  patches = dmp.patch_make(
+      "abcdefghij , h : 0 , t : 1 abcdefghij , h : 0 , t : 1 abcdefghij , h : "
+      "0 , t : 1",
+      "abcdefghij , h : 1 , t : 1 abcdefghij , h : 1 , t : 1 abcdefghij , h : "
+      "0 , t : 1");
   dmp.patch_splitMax(patches);
-  assertEquals("patch_splitMax: #4.", "@@ -2,32 +2,32 @@\n bcdefghij , h : \n-0\n+1\n  , t : 1 abcdef\n@@ -29,32 +29,32 @@\n bcdefghij , h : \n-0\n+1\n  , t : 1 abcdef\n", dmp.patch_toText(patches));
+  assertEquals(
+      "patch_splitMax: #4.",
+      "@@ -2,32 +2,32 @@\n bcdefghij , h : \n-0\n+1\n  , t : 1 abcdef\n@@ "
+      "-29,32 +29,32 @@\n bcdefghij , h : \n-0\n+1\n  , t : 1 abcdef\n",
+      dmp.patch_toText(patches));
 }
 
 void diff_match_patch_test::testPatchAddPadding() {
   QList<Patch> patches;
   patches = dmp.patch_make("", "test");
-  assertEquals("patch_addPadding: Both edges full.", "@@ -0,0 +1,4 @@\n+test\n", dmp.patch_toText(patches));
+  assertEquals("patch_addPadding: Both edges full.", "@@ -0,0 +1,4 @@\n+test\n",
+               dmp.patch_toText(patches));
   dmp.patch_addPadding(patches);
-  assertEquals("patch_addPadding: Both edges full.", "@@ -1,8 +1,12 @@\n %01%02%03%04\n+test\n %01%02%03%04\n", dmp.patch_toText(patches));
+  assertEquals("patch_addPadding: Both edges full.",
+               "@@ -1,8 +1,12 @@\n %01%02%03%04\n+test\n %01%02%03%04\n",
+               dmp.patch_toText(patches));
 
   patches = dmp.patch_make("XY", "XtestY");
-  assertEquals("patch_addPadding: Both edges partial.", "@@ -1,2 +1,6 @@\n X\n+test\n Y\n", dmp.patch_toText(patches));
+  assertEquals("patch_addPadding: Both edges partial.",
+               "@@ -1,2 +1,6 @@\n X\n+test\n Y\n", dmp.patch_toText(patches));
   dmp.patch_addPadding(patches);
-  assertEquals("patch_addPadding: Both edges partial.", "@@ -2,8 +2,12 @@\n %02%03%04X\n+test\n Y%01%02%03\n", dmp.patch_toText(patches));
+  assertEquals("patch_addPadding: Both edges partial.",
+               "@@ -2,8 +2,12 @@\n %02%03%04X\n+test\n Y%01%02%03\n",
+               dmp.patch_toText(patches));
 
   patches = dmp.patch_make("XXXXYYYY", "XXXXtestYYYY");
-  assertEquals("patch_addPadding: Both edges none.", "@@ -1,8 +1,12 @@\n XXXX\n+test\n YYYY\n", dmp.patch_toText(patches));
+  assertEquals("patch_addPadding: Both edges none.",
+               "@@ -1,8 +1,12 @@\n XXXX\n+test\n YYYY\n",
+               dmp.patch_toText(patches));
   dmp.patch_addPadding(patches);
-  assertEquals("patch_addPadding: Both edges none.", "@@ -5,8 +5,12 @@\n XXXX\n+test\n YYYY\n", dmp.patch_toText(patches));
+  assertEquals("patch_addPadding: Both edges none.",
+               "@@ -5,8 +5,12 @@\n XXXX\n+test\n YYYY\n",
+               dmp.patch_toText(patches));
 }
 
 void diff_match_patch_test::testPatchApply() {
@@ -847,67 +1185,116 @@ void diff_match_patch_test::testPatchApply() {
   dmp.Patch_DeleteThreshold = 0.5f;
   QList<Patch> patches;
   patches = dmp.patch_make("", "");
-  QPair<QString, QVector<bool> > results = dmp.patch_apply(patches, "Hello world.");
+  QPair<QString, QVector<bool> > results =
+      dmp.patch_apply(patches, "Hello world.");
   QVector<bool> boolArray = results.second;
 
-  QString resultStr = QString("%1\t%2").arg(results.first).arg(boolArray.count());
+  QString resultStr =
+      QString("%1\t%2").arg(results.first).arg(boolArray.count());
   assertEquals("patch_apply: Null case.", "Hello world.\t0", resultStr);
 
-  patches = dmp.patch_make("The quick brown fox jumps over the lazy dog.", "That quick brown fox jumped over a lazy dog.");
-  results = dmp.patch_apply(patches, "The quick brown fox jumps over the lazy dog.");
+  patches = dmp.patch_make("The quick brown fox jumps over the lazy dog.",
+                           "That quick brown fox jumped over a lazy dog.");
+  results =
+      dmp.patch_apply(patches, "The quick brown fox jumps over the lazy dog.");
   boolArray = results.second;
-  resultStr = results.first + "\t" + (boolArray[0] ? "true" : "false") + "\t" + (boolArray[1] ? "true" : "false");
-  assertEquals("patch_apply: Exact match.", "That quick brown fox jumped over a lazy dog.\ttrue\ttrue", resultStr);
+  resultStr = results.first + "\t" + (boolArray[0] ? "true" : "false") + "\t" +
+              (boolArray[1] ? "true" : "false");
+  assertEquals("patch_apply: Exact match.",
+               "That quick brown fox jumped over a lazy dog.\ttrue\ttrue",
+               resultStr);
 
-  results = dmp.patch_apply(patches, "The quick red rabbit jumps over the tired tiger.");
+  results = dmp.patch_apply(patches,
+                            "The quick red rabbit jumps over the tired tiger.");
   boolArray = results.second;
-  resultStr = results.first + "\t" + (boolArray[0] ? "true" : "false") + "\t" + (boolArray[1] ? "true" : "false");
-  assertEquals("patch_apply: Partial match.", "That quick red rabbit jumped over a tired tiger.\ttrue\ttrue", resultStr);
+  resultStr = results.first + "\t" + (boolArray[0] ? "true" : "false") + "\t" +
+              (boolArray[1] ? "true" : "false");
+  assertEquals("patch_apply: Partial match.",
+               "That quick red rabbit jumped over a tired tiger.\ttrue\ttrue",
+               resultStr);
 
-  results = dmp.patch_apply(patches, "I am the very model of a modern major general.");
+  results = dmp.patch_apply(patches,
+                            "I am the very model of a modern major general.");
   boolArray = results.second;
-  resultStr = results.first + "\t" + (boolArray[0] ? "true" : "false") + "\t" + (boolArray[1] ? "true" : "false");
-  assertEquals("patch_apply: Failed match.", "I am the very model of a modern major general.\tfalse\tfalse", resultStr);
+  resultStr = results.first + "\t" + (boolArray[0] ? "true" : "false") + "\t" +
+              (boolArray[1] ? "true" : "false");
+  assertEquals("patch_apply: Failed match.",
+               "I am the very model of a modern major general.\tfalse\tfalse",
+               resultStr);
 
-  patches = dmp.patch_make("x1234567890123456789012345678901234567890123456789012345678901234567890y", "xabcy");
-  results = dmp.patch_apply(patches, "x123456789012345678901234567890-----++++++++++-----123456789012345678901234567890y");
+  patches = dmp.patch_make(
+      "x1234567890123456789012345678901234567890123456789012345678901234567890"
+      "y",
+      "xabcy");
+  results = dmp.patch_apply(patches,
+                            "x123456789012345678901234567890-----++++++++++----"
+                            "-123456789012345678901234567890y");
   boolArray = results.second;
-  resultStr = results.first + "\t" + (boolArray[0] ? "true" : "false") + "\t" + (boolArray[1] ? "true" : "false");
-  assertEquals("patch_apply: Big delete, small change.", "xabcy\ttrue\ttrue", resultStr);
+  resultStr = results.first + "\t" + (boolArray[0] ? "true" : "false") + "\t" +
+              (boolArray[1] ? "true" : "false");
+  assertEquals("patch_apply: Big delete, small change.", "xabcy\ttrue\ttrue",
+               resultStr);
 
-  patches = dmp.patch_make("x1234567890123456789012345678901234567890123456789012345678901234567890y", "xabcy");
-  results = dmp.patch_apply(patches, "x12345678901234567890---------------++++++++++---------------12345678901234567890y");
+  patches = dmp.patch_make(
+      "x1234567890123456789012345678901234567890123456789012345678901234567890"
+      "y",
+      "xabcy");
+  results = dmp.patch_apply(patches,
+                            "x12345678901234567890---------------++++++++++----"
+                            "-----------12345678901234567890y");
   boolArray = results.second;
-  resultStr = results.first + "\t" + (boolArray[0] ? "true" : "false") + "\t" + (boolArray[1] ? "true" : "false");
-  assertEquals("patch_apply: Big delete, large change 1.", "xabc12345678901234567890---------------++++++++++---------------12345678901234567890y\tfalse\ttrue", resultStr);
+  resultStr = results.first + "\t" + (boolArray[0] ? "true" : "false") + "\t" +
+              (boolArray[1] ? "true" : "false");
+  assertEquals("patch_apply: Big delete, large change 1.",
+               "xabc12345678901234567890---------------++++++++++--------------"
+               "-12345678901234567890y\tfalse\ttrue",
+               resultStr);
 
   dmp.Patch_DeleteThreshold = 0.6f;
-  patches = dmp.patch_make("x1234567890123456789012345678901234567890123456789012345678901234567890y", "xabcy");
-  results = dmp.patch_apply(patches, "x12345678901234567890---------------++++++++++---------------12345678901234567890y");
+  patches = dmp.patch_make(
+      "x1234567890123456789012345678901234567890123456789012345678901234567890"
+      "y",
+      "xabcy");
+  results = dmp.patch_apply(patches,
+                            "x12345678901234567890---------------++++++++++----"
+                            "-----------12345678901234567890y");
   boolArray = results.second;
-  resultStr = results.first + "\t" + (boolArray[0] ? "true" : "false") + "\t" + (boolArray[1] ? "true" : "false");
-  assertEquals("patch_apply: Big delete, large change 2.", "xabcy\ttrue\ttrue", resultStr);
+  resultStr = results.first + "\t" + (boolArray[0] ? "true" : "false") + "\t" +
+              (boolArray[1] ? "true" : "false");
+  assertEquals("patch_apply: Big delete, large change 2.", "xabcy\ttrue\ttrue",
+               resultStr);
   dmp.Patch_DeleteThreshold = 0.5f;
 
   dmp.Match_Threshold = 0.0f;
   dmp.Match_Distance = 0;
-  patches = dmp.patch_make("abcdefghijklmnopqrstuvwxyz--------------------1234567890", "abcXXXXXXXXXXdefghijklmnopqrstuvwxyz--------------------1234567YYYYYYYYYY890");
-  results = dmp.patch_apply(patches, "ABCDEFGHIJKLMNOPQRSTUVWXYZ--------------------1234567890");
+  patches =
+      dmp.patch_make("abcdefghijklmnopqrstuvwxyz--------------------1234567890",
+                     "abcXXXXXXXXXXdefghijklmnopqrstuvwxyz--------------------"
+                     "1234567YYYYYYYYYY890");
+  results = dmp.patch_apply(
+      patches, "ABCDEFGHIJKLMNOPQRSTUVWXYZ--------------------1234567890");
   boolArray = results.second;
-  resultStr = results.first + "\t" + (boolArray[0] ? "true" : "false") + "\t" + (boolArray[1] ? "true" : "false");
-  assertEquals("patch_apply: Compensate for failed patch.", "ABCDEFGHIJKLMNOPQRSTUVWXYZ--------------------1234567YYYYYYYYYY890\tfalse\ttrue", resultStr);
+  resultStr = results.first + "\t" + (boolArray[0] ? "true" : "false") + "\t" +
+              (boolArray[1] ? "true" : "false");
+  assertEquals("patch_apply: Compensate for failed patch.",
+               "ABCDEFGHIJKLMNOPQRSTUVWXYZ--------------------"
+               "1234567YYYYYYYYYY890\tfalse\ttrue",
+               resultStr);
   dmp.Match_Threshold = 0.5f;
   dmp.Match_Distance = 1000;
 
   patches = dmp.patch_make("", "test");
   QString patchStr = dmp.patch_toText(patches);
   dmp.patch_apply(patches, "");
-  assertEquals("patch_apply: No side effects.", patchStr, dmp.patch_toText(patches));
+  assertEquals("patch_apply: No side effects.", patchStr,
+               dmp.patch_toText(patches));
 
-  patches = dmp.patch_make("The quick brown fox jumps over the lazy dog.", "Woof");
+  patches =
+      dmp.patch_make("The quick brown fox jumps over the lazy dog.", "Woof");
   patchStr = dmp.patch_toText(patches);
   dmp.patch_apply(patches, "The quick brown fox jumps over the lazy dog.");
-  assertEquals("patch_apply: No side effects with major delete.", patchStr, dmp.patch_toText(patches));
+  assertEquals("patch_apply: No side effects with major delete.", patchStr,
+               dmp.patch_toText(patches));
 
   patches = dmp.patch_make("", "test");
   results = dmp.patch_apply(patches, "");
@@ -919,7 +1306,8 @@ void diff_match_patch_test::testPatchApply() {
   results = dmp.patch_apply(patches, "XY");
   boolArray = results.second;
   resultStr = results.first + "\t" + (boolArray[0] ? "true" : "false");
-  assertEquals("patch_apply: Near edge exact match.", "XtestY\ttrue", resultStr);
+  assertEquals("patch_apply: Near edge exact match.", "XtestY\ttrue",
+               resultStr);
 
   patches = dmp.patch_make("y", "y123");
   results = dmp.patch_apply(patches, "x");
@@ -928,8 +1316,8 @@ void diff_match_patch_test::testPatchApply() {
   assertEquals("patch_apply: Edge partial match.", "x123\ttrue", resultStr);
 }
 
-
-void diff_match_patch_test::assertEquals(const QString &strCase, int n1, int n2) {
+void diff_match_patch_test::assertEquals(const QString &strCase, int n1,
+                                         int n2) {
   if (n1 != n2) {
     qDebug("%s FAIL\nExpected: %d\nActual: %d", qPrintable(strCase), n1, n2);
     throw strCase;
@@ -937,29 +1325,33 @@ void diff_match_patch_test::assertEquals(const QString &strCase, int n1, int n2)
   qDebug("%s OK", qPrintable(strCase));
 }
 
-void diff_match_patch_test::assertEquals(const QString &strCase, const QString &s1, const QString &s2) {
+void diff_match_patch_test::assertEquals(const QString &strCase,
+                                         const QString &s1, const QString &s2) {
   if (s1 != s2) {
-    qDebug("%s FAIL\nExpected: %s\nActual: %s",
-           qPrintable(strCase), qPrintable(s1), qPrintable(s2));
+    qDebug("%s FAIL\nExpected: %s\nActual: %s", qPrintable(strCase),
+           qPrintable(s1), qPrintable(s2));
     throw strCase;
   }
   qDebug("%s OK", qPrintable(strCase));
 }
 
-void diff_match_patch_test::assertEquals(const QString &strCase, const Diff &d1, const Diff &d2) {
+void diff_match_patch_test::assertEquals(const QString &strCase, const Diff &d1,
+                                         const Diff &d2) {
   if (d1 != d2) {
     qDebug("%s FAIL\nExpected: %s\nActual: %s", qPrintable(strCase),
-        qPrintable(d1.toString()), qPrintable(d2.toString()));
+           qPrintable(d1.toString()), qPrintable(d2.toString()));
     throw strCase;
   }
   qDebug("%s OK", qPrintable(strCase));
 }
 
-void diff_match_patch_test::assertEquals(const QString &strCase, const QList<Diff> &list1, const QList<Diff> &list2) {
+void diff_match_patch_test::assertEquals(const QString &strCase,
+                                         const QList<Diff> &list1,
+                                         const QList<Diff> &list2) {
   bool fail = false;
   if (list1.count() == list2.count()) {
     int i = 0;
-    foreach(Diff d1, list1) {
+    foreach (Diff d1, list1) {
       Diff d2 = list2.value(i);
       if (d1 != d2) {
         fail = true;
@@ -975,7 +1367,7 @@ void diff_match_patch_test::assertEquals(const QString &strCase, const QList<Dif
     // Build human readable description of both lists.
     QString listString1 = "(";
     bool first = true;
-    foreach(Diff d1, list1) {
+    foreach (Diff d1, list1) {
       if (!first) {
         listString1 += ", ";
       }
@@ -985,7 +1377,7 @@ void diff_match_patch_test::assertEquals(const QString &strCase, const QList<Dif
     listString1 += ")";
     QString listString2 = "(";
     first = true;
-    foreach(Diff d2, list2) {
+    foreach (Diff d2, list2) {
       if (!first) {
         listString2 += ", ";
       }
@@ -993,18 +1385,20 @@ void diff_match_patch_test::assertEquals(const QString &strCase, const QList<Dif
       first = false;
     }
     listString2 += ")";
-    qDebug("%s FAIL\nExpected: %s\nActual: %s",
-        qPrintable(strCase), qPrintable(listString1), qPrintable(listString2));
+    qDebug("%s FAIL\nExpected: %s\nActual: %s", qPrintable(strCase),
+           qPrintable(listString1), qPrintable(listString2));
     throw strCase;
   }
   qDebug("%s OK", qPrintable(strCase));
 }
 
-void diff_match_patch_test::assertEquals(const QString &strCase, const QList<QVariant> &list1, const QList<QVariant> &list2) {
+void diff_match_patch_test::assertEquals(const QString &strCase,
+                                         const QList<QVariant> &list1,
+                                         const QList<QVariant> &list2) {
   bool fail = false;
   if (list1.count() == list2.count()) {
     int i = 0;
-    foreach(QVariant q1, list1) {
+    foreach (QVariant q1, list1) {
       QVariant q2 = list2.value(i);
       if (q1 != q2) {
         fail = true;
@@ -1020,7 +1414,7 @@ void diff_match_patch_test::assertEquals(const QString &strCase, const QList<QVa
     // Build human readable description of both lists.
     QString listString1 = "(";
     bool first = true;
-    foreach(QVariant q1, list1) {
+    foreach (QVariant q1, list1) {
       if (!first) {
         listString1 += ", ";
       }
@@ -1030,7 +1424,7 @@ void diff_match_patch_test::assertEquals(const QString &strCase, const QList<QVa
     listString1 += ")";
     QString listString2 = "(";
     first = true;
-    foreach(QVariant q2, list2) {
+    foreach (QVariant q2, list2) {
       if (!first) {
         listString2 += ", ";
       }
@@ -1038,54 +1432,61 @@ void diff_match_patch_test::assertEquals(const QString &strCase, const QList<QVa
       first = false;
     }
     listString2 += ")";
-    qDebug("%s FAIL\nExpected: %s\nActual: %s",
-        qPrintable(strCase), qPrintable(listString1), qPrintable(listString2));
+    qDebug("%s FAIL\nExpected: %s\nActual: %s", qPrintable(strCase),
+           qPrintable(listString1), qPrintable(listString2));
     throw strCase;
   }
   qDebug("%s OK", qPrintable(strCase));
 }
 
-void diff_match_patch_test::assertEquals(const QString &strCase, const QVariant &var1, const QVariant &var2) {
+void diff_match_patch_test::assertEquals(const QString &strCase,
+                                         const QVariant &var1,
+                                         const QVariant &var2) {
   if (var1 != var2) {
     qDebug("%s FAIL\nExpected: %s\nActual: %s", qPrintable(strCase),
-        qPrintable(var1.toString()), qPrintable(var2.toString()));
+           qPrintable(var1.toString()), qPrintable(var2.toString()));
     throw strCase;
   }
   qDebug("%s OK", qPrintable(strCase));
 }
 
-void diff_match_patch_test::assertEquals(const QString &strCase, const QMap<QChar, int> &m1, const QMap<QChar, int> &m2) {
+void diff_match_patch_test::assertEquals(const QString &strCase,
+                                         const QMap<QChar, int> &m1,
+                                         const QMap<QChar, int> &m2) {
   QMapIterator<QChar, int> i1(m1), i2(m2);
 
   while (i1.hasNext() && i2.hasNext()) {
     i1.next();
     i2.next();
     if (i1.key() != i2.key() || i1.value() != i2.value()) {
-      qDebug("%s FAIL\nExpected: (%c, %d)\nActual: (%c, %d)", qPrintable(strCase),
-          i1.key().toLatin1(), i1.value(), i2.key().toLatin1(), i2.value());
+      qDebug("%s FAIL\nExpected: (%c, %d)\nActual: (%c, %d)",
+             qPrintable(strCase), i1.key().toLatin1(), i1.value(),
+             i2.key().toLatin1(), i2.value());
       throw strCase;
     }
   }
 
   if (i1.hasNext()) {
     i1.next();
-    qDebug("%s FAIL\nExpected: (%c, %d)\nActual: none",
-        qPrintable(strCase), i1.key().toLatin1(), i1.value());
+    qDebug("%s FAIL\nExpected: (%c, %d)\nActual: none", qPrintable(strCase),
+           i1.key().toLatin1(), i1.value());
     throw strCase;
   }
   if (i2.hasNext()) {
     i2.next();
-    qDebug("%s FAIL\nExpected: none\nActual: (%c, %d)",
-        qPrintable(strCase), i2.key().toLatin1(), i2.value());
+    qDebug("%s FAIL\nExpected: none\nActual: (%c, %d)", qPrintable(strCase),
+           i2.key().toLatin1(), i2.value());
     throw strCase;
   }
   qDebug("%s OK", qPrintable(strCase));
 }
 
-void diff_match_patch_test::assertEquals(const QString &strCase, const QStringList &list1, const QStringList &list2) {
+void diff_match_patch_test::assertEquals(const QString &strCase,
+                                         const QStringList &list1,
+                                         const QStringList &list2) {
   if (list1 != list2) {
     qDebug("%s FAIL\nExpected: %s\nActual: %s", qPrintable(strCase),
-        qPrintable(list1.join(",")), qPrintable(list2.join(",")));
+           qPrintable(list1.join(",")), qPrintable(list2.join(",")));
     throw strCase;
   }
   qDebug("%s OK", qPrintable(strCase));
@@ -1107,7 +1508,6 @@ void diff_match_patch_test::assertFalse(const QString &strCase, bool value) {
   qDebug("%s OK", qPrintable(strCase));
 }
 
-
 // Construct the two texts which made up the diff originally.
 QStringList diff_match_patch_test::diff_rebuildtexts(QList<Diff> diffs) {
   QStringList text;
@@ -1123,16 +1523,17 @@ QStringList diff_match_patch_test::diff_rebuildtexts(QList<Diff> diffs) {
   return text;
 }
 
-void diff_match_patch_test::assertEmpty(const QString &strCase, const QStringList &list) {
+void diff_match_patch_test::assertEmpty(const QString &strCase,
+                                        const QStringList &list) {
   if (!list.isEmpty()) {
     throw strCase;
   }
 }
 
-
 // Private function for quickly building lists of diffs.
-QList<Diff> diff_match_patch_test::diffList(Diff d1, Diff d2, Diff d3, Diff d4, Diff d5,
-  Diff d6, Diff d7, Diff d8, Diff d9, Diff d10) {
+QList<Diff> diff_match_patch_test::diffList(Diff d1, Diff d2, Diff d3, Diff d4,
+                                            Diff d5, Diff d6, Diff d7, Diff d8,
+                                            Diff d9, Diff d10) {
   // Diff(Insert, NULL) is invalid and thus is used as the default argument.
   QList<Diff> listRet;
   if (d1.operation == Insert && d1.text == NULL) {
@@ -1188,14 +1589,13 @@ QList<Diff> diff_match_patch_test::diffList(Diff d1, Diff d2, Diff d3, Diff d4, 
   return listRet;
 }
 
-
 /*
 Compile instructions for MinGW and QT4 on Windows:
 qmake -project
 qmake
 mingw32-make
-g++ -o diff_match_patch_test debug\diff_match_patch_test.o debug\diff_match_patch.o \qt4\lib\libQtCore4.a
-diff_match_patch_test.exe
+g++ -o diff_match_patch_test debug\diff_match_patch_test.o
+debug\diff_match_patch.o \qt4\lib\libQtCore4.a diff_match_patch_test.exe
 
 Compile insructions for OS X:
 qmake -spec macx-g++

--- a/cpp/diff_match_patch_test.cpp
+++ b/cpp/diff_match_patch_test.cpp
@@ -1099,7 +1099,7 @@ void diff_match_patch_test::testPatchMake() {
 
   // Test null inputs.
   try {
-    dmp.patch_make(NULL, NULL);
+    dmp.patch_make(nullptr, nullptr);
     assertFalse("patch_make: Null inputs.", true);
   } catch (const char *ex) {
     // Exception expected.
@@ -1534,54 +1534,54 @@ void diff_match_patch_test::assertEmpty(const QString &strCase,
 QList<Diff> diff_match_patch_test::diffList(Diff d1, Diff d2, Diff d3, Diff d4,
                                             Diff d5, Diff d6, Diff d7, Diff d8,
                                             Diff d9, Diff d10) {
-  // Diff(Insert, NULL) is invalid and thus is used as the default argument.
+  // Diff(Insert, nullptr) is invalid and thus is used as the default argument.
   QList<Diff> listRet;
-  if (d1.operation == Insert && d1.text == NULL) {
+  if (d1.operation == Insert && d1.text.isNull()) {
     return listRet;
   }
   listRet << d1;
 
-  if (d2.operation == Insert && d2.text == NULL) {
+  if (d2.operation == Insert && d2.text.isNull()) {
     return listRet;
   }
   listRet << d2;
 
-  if (d3.operation == Insert && d3.text == NULL) {
+  if (d3.operation == Insert && d3.text.isNull()) {
     return listRet;
   }
   listRet << d3;
 
-  if (d4.operation == Insert && d4.text == NULL) {
+  if (d4.operation == Insert && d4.text.isNull()) {
     return listRet;
   }
   listRet << d4;
 
-  if (d5.operation == Insert && d5.text == NULL) {
+  if (d5.operation == Insert && d5.text.isNull()) {
     return listRet;
   }
   listRet << d5;
 
-  if (d6.operation == Insert && d6.text == NULL) {
+  if (d6.operation == Insert && d6.text.isNull()) {
     return listRet;
   }
   listRet << d6;
 
-  if (d7.operation == Insert && d7.text == NULL) {
+  if (d7.operation == Insert && d7.text.isNull()) {
     return listRet;
   }
   listRet << d7;
 
-  if (d8.operation == Insert && d8.text == NULL) {
+  if (d8.operation == Insert && d8.text.isNull()) {
     return listRet;
   }
   listRet << d8;
 
-  if (d9.operation == Insert && d9.text == NULL) {
+  if (d9.operation == Insert && d9.text.isNull()) {
     return listRet;
   }
   listRet << d9;
 
-  if (d10.operation == Insert && d10.text == NULL) {
+  if (d10.operation == Insert && d10.text.isNull()) {
     return listRet;
   }
   listRet << d10;

--- a/cpp/diff_match_patch_test.cpp
+++ b/cpp/diff_match_patch_test.cpp
@@ -28,9 +28,9 @@
 int main(int argc, char **argv) {
   diff_match_patch_test dmp_test;
   qDebug("Starting diff_match_patch unit tests.");
-  dmp_test.run_all_tests();
+  int result = dmp_test.run_all_tests();
   qDebug("Done.");
-  return 0;
+  return result;
   Q_UNUSED(argc)
   Q_UNUSED(argv)
 }
@@ -39,8 +39,9 @@ int main(int argc, char **argv) {
 diff_match_patch_test::diff_match_patch_test() {
 }
 
-void diff_match_patch_test::run_all_tests() {
+int diff_match_patch_test::run_all_tests() {
   QTime t;
+  int result = 0;
   t.start();
   try {
     testDiffCommonPrefix();
@@ -76,8 +77,10 @@ void diff_match_patch_test::run_all_tests() {
     qDebug("All tests passed.");
   } catch (QString strCase) {
     qDebug("Test failed: %s", qPrintable(strCase));
+    result = -1;
   }
   qDebug("Total time: %d ms", t.elapsed());
+  return result;
 }
 
 //  DIFF TEST FUNCTIONS

--- a/cpp/diff_match_patch_test.h
+++ b/cpp/diff_match_patch_test.h
@@ -27,7 +27,7 @@
 class diff_match_patch_test {
  public:
   diff_match_patch_test();
-  void run_all_tests();
+  int run_all_tests();
 
   //  DIFF TEST FUNCTIONS
   void testDiffCommonPrefix();

--- a/cpp/diff_match_patch_test.h
+++ b/cpp/diff_match_patch_test.h
@@ -20,7 +20,6 @@
 // Original file licensed under the Apache License, Version 2.0
 // See the LICENSE file for the original license text.
 
-
 #ifndef DIFF_MATCH_PATCH_TEST_H
 #define DIFF_MATCH_PATCH_TEST_H
 
@@ -68,13 +67,19 @@ class diff_match_patch_test {
 
   // Define equality.
   void assertEquals(const QString &strCase, int n1, int n2);
-  void assertEquals(const QString &strCase, const QString &s1, const QString &s2);
+  void assertEquals(const QString &strCase, const QString &s1,
+                    const QString &s2);
   void assertEquals(const QString &strCase, const Diff &d1, const Diff &d2);
-  void assertEquals(const QString &strCase, const QList<Diff> &list1, const QList<Diff> &list2);
-  void assertEquals(const QString &strCase, const QList<QVariant> &list1, const QList<QVariant> &list2);
-  void assertEquals(const QString &strCase, const QVariant &var1, const QVariant &var2);
-  void assertEquals(const QString &strCase, const QMap<QChar, int> &m1, const QMap<QChar, int> &m2);
-  void assertEquals(const QString &strCase, const QStringList &list1, const QStringList &list2);
+  void assertEquals(const QString &strCase, const QList<Diff> &list1,
+                    const QList<Diff> &list2);
+  void assertEquals(const QString &strCase, const QList<QVariant> &list1,
+                    const QList<QVariant> &list2);
+  void assertEquals(const QString &strCase, const QVariant &var1,
+                    const QVariant &var2);
+  void assertEquals(const QString &strCase, const QMap<QChar, int> &m1,
+                    const QMap<QChar, int> &m2);
+  void assertEquals(const QString &strCase, const QStringList &list1,
+                    const QStringList &list2);
   void assertTrue(const QString &strCase, bool value);
   void assertFalse(const QString &strCase, bool value);
   void assertEmpty(const QString &strCase, const QStringList &list);
@@ -91,4 +96,4 @@ class diff_match_patch_test {
       Diff d9 = Diff(Insert, NULL), Diff d10 = Diff(Insert, NULL));
 };
 
-#endif // DIFF_MATCH_PATCH_TEST_H
+#endif  // DIFF_MATCH_PATCH_TEST_H


### PR DESCRIPTION
Hi @gk017 !

I plan to use this Qt/C++ for one of my project and I was wondering if you would accept this small Qt 6 compatibility fix.

I didn't read carefully the code but I currently have one test failing:

```
Starting diff_match_patch unit tests.
diff_commonPrefix: Null case. OK
diff_commonPrefix: Non-null case. OK
diff_commonPrefix: Whole case. OK
diff_commonSuffix: Null case. OK
diff_commonSuffix: Non-null case. OK
diff_commonSuffix: Whole case. OK
diff_commonOverlap: Null case. OK
diff_commonOverlap: Whole case. OK
diff_commonOverlap: No overlap. OK
diff_commonOverlap: Overlap. OK
diff_commonOverlap: Unicode. OK
diff_halfMatch: Single Match #1. OK
diff_halfMatch: Single Match #2. OK
diff_halfMatch: Single Match #3. OK
diff_halfMatch: Single Match #4. OK
diff_halfMatch: Multiple Matches #1. OK
diff_halfMatch: Multiple Matches #2. OK
diff_halfMatch: Multiple Matches #3. OK
diff_halfMatch: Non-optimal halfmatch. OK
diff_linesToChars: OK
diff_linesToChars: OK
diff_linesToChars: OK
diff_linesToChars: More than 256 (setup). OK
diff_linesToChars: More than 256 (setup). OK
diff_linesToChars: More than 256. OK
diff_charsToLines: OK
diff_charsToLines: OK
diff_charsToLines: OK
diff_linesToChars: More than 256 (setup). OK
diff_linesToChars: More than 256 (setup). OK
diff_charsToLines: More than 256. OK
diff_cleanupMerge: Null case. OK
diff_cleanupMerge: No change case. OK
diff_cleanupMerge: Merge equalities. OK
diff_cleanupMerge: Merge deletions. OK
diff_cleanupMerge: Merge insertions. OK
diff_cleanupMerge: Merge interweave. OK
diff_cleanupMerge: Prefix and suffix detection. OK
diff_cleanupMerge: Prefix and suffix detection with equalities. OK
diff_cleanupMerge: Slide edit left. OK
diff_cleanupMerge: Slide edit right. OK
diff_cleanupMerge: Slide edit left recursive. OK
diff_cleanupMerge: Slide edit right recursive. OK
diff_cleanupSemantic: Null case. OK
diff_cleanupSemanticLossless: Blank lines. OK
diff_cleanupSemanticLossless: Line boundaries. OK
diff_cleanupSemantic: Word boundaries. OK
diff_cleanupSemantic: Alphanumeric boundaries. OK
diff_cleanupSemantic: Hitting the start. OK
diff_cleanupSemantic: Hitting the end. OK
diff_cleanupSemantic: Sentence boundaries. OK
diff_cleanupSemantic: Null case. OK
diff_cleanupSemantic: No elimination #1. OK
diff_cleanupSemantic: No elimination #2. OK
diff_cleanupSemantic: Simple elimination. OK
diff_cleanupSemantic: Backpass elimination. OK
diff_cleanupSemantic: Multiple elimination. OK
diff_cleanupSemantic: Word boundaries. OK
diff_cleanupSemantic: No overlap elimination. OK
diff_cleanupSemantic: Overlap elimination. FAIL
Expected: (Diff(Delete,"abc"), Diff(Equal,"xxx"), Diff(Insert,"def"))
Actual: (Diff(Delete,"abc"), Diff(Equal,"def"), Diff(Insert,"xxxdef"))
Test failed: diff_cleanupSemantic: Overlap elimination.
Total time: 0 ms
Done.
```

Do you also have this issue ?